### PR TITLE
CBOR encoding, minor fixes

### DIFF
--- a/public/assets/button.svg
+++ b/public/assets/button.svg
@@ -36,9 +36,9 @@
    inkscape:pagecheckerboard="1"
    inkscape:deskcolor="#505050"
    showgrid="false"
-   inkscape:zoom="0.77441408"
-   inkscape:cx="134.29508"
-   inkscape:cy="256.32282"
+   inkscape:zoom="0.54759345"
+   inkscape:cx="19.174809"
+   inkscape:cy="112.3096"
    inkscape:window-width="1920"
    inkscape:window-height="996"
    inkscape:window-x="-8"
@@ -52,7 +52,7 @@
 </style>
 
 <rect
-   style="fill:#898574;fill-opacity:1;stroke:none;stroke-width:14.497;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+   style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:14.497;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
    id="rect287-8"
    width="458.98367"
    height="466.608"

--- a/public/js/modules/tf.js
+++ b/public/js/modules/tf.js
@@ -83,7 +83,8 @@ export class TF {
 			ros: rosbridge.ros,
 			name: 'vizanti/tf_consolidated',
 			messageType: 'tf/tfMessage',
-			throttle_rate: 33
+			throttle_rate: 33,
+			compression: "cbor"
 		});
 		
 		const setListener = () => {
@@ -104,7 +105,7 @@ export class TF {
 		this.tf_static_topic = new ROSLIB.Topic({
 			ros: rosbridge.ros,
 			name: 'tf_static',
-			messageType: 'tf/tfMessage',
+			messageType: 'tf/tfMessage'
 		});
 
 		this.tf_static_listener = this.tf_static_topic.subscribe((msg) => {

--- a/public/templates/button/button_script.js
+++ b/public/templates/button/button_script.js
@@ -22,7 +22,7 @@ if(settings.hasOwnProperty("{uniqueID}")){
 	topic = loaded_data.topic;
 	namebox.value = loaded_data.text;
 	icontext.textContent = loaded_data.text;
-	typedict = loaded_data.typedict;
+	typedict = loaded_data.typedict ?? {};
 }
 
 function saveSettings(){

--- a/public/templates/compressedimage/compressedimage_script.js
+++ b/public/templates/compressedimage/compressedimage_script.js
@@ -111,8 +111,7 @@ function connect(){
 		ros : rosbridge.ros,
 		name : topic,
 		messageType : 'sensor_msgs/CompressedImage',
-		throttle_rate: parseInt(throttle.value),
-		compression: "cbor"
+		throttle_rate: parseInt(throttle.value)
 	});
 	
 	listener = image_topic.subscribe(async (msg) => {  

--- a/public/templates/compressedimage/compressedimage_script.js
+++ b/public/templates/compressedimage/compressedimage_script.js
@@ -111,7 +111,8 @@ function connect(){
 		ros : rosbridge.ros,
 		name : topic,
 		messageType : 'sensor_msgs/CompressedImage',
-		throttle_rate: parseInt(throttle.value)
+		throttle_rate: parseInt(throttle.value),
+		compression: "cbor"
 	});
 	
 	listener = image_topic.subscribe(async (msg) => {  

--- a/public/templates/map/map_script.js
+++ b/public/templates/map/map_script.js
@@ -191,7 +191,9 @@ function connect(){
 		ros : rosbridge.ros,
 		name : topic,
 		messageType : 'nav_msgs/OccupancyGrid',
-		throttle_rate: 2000 // throttle to once every two seconds max
+		throttle_rate: 2000, // throttle to once every two seconds max
+		compression: "cbor"
+		
 	});
 	
 	listener = map_topic.subscribe((msg) => {

--- a/public/templates/markerarray/markerarray_script.js
+++ b/public/templates/markerarray/markerarray_script.js
@@ -224,7 +224,8 @@ function connect(){
 	marker_topic = new ROSLIB.Topic({
 		ros : rosbridge.ros,
 		name : topic,
-		messageType : 'visualization_msgs/MarkerArray'
+		messageType : 'visualization_msgs/MarkerArray',
+		compression: "cbor"
 	});
 	
 	listener = marker_topic.subscribe((msg) => {

--- a/public/templates/path/path_modal.html
+++ b/public/templates/path/path_modal.html
@@ -8,6 +8,13 @@
 			<!-- add topics here-->
 		</select>
 
+		<br>
+
+		<label for="{uniqueID}_colorpicker">Colour:</label>
+		<input type="color" value="#5ED753" id="{uniqueID}_colorpicker">
+
+		<br>
+
 		<p>Display a navigation path.</p>
 
 		<hr>

--- a/public/templates/path/path_script.js
+++ b/public/templates/path/path_script.js
@@ -15,15 +15,22 @@ const icon = document.getElementById("{uniqueID}_icon").getElementsByTagName('im
 const canvas = document.getElementById('{uniqueID}_canvas');
 const ctx = canvas.getContext('2d');
 
+const colourpicker = document.getElementById("{uniqueID}_colorpicker");
+colourpicker.addEventListener("input", (event) =>{
+	saveSettings();
+});
+
 //Settings
 if(settings.hasOwnProperty("{uniqueID}")){
 	const loaded_data  = settings["{uniqueID}"];
 	topic = loaded_data.topic;
+	colourpicker.value = loaded_data.color ?? "#5ED753";
 }
 
 function saveSettings(){
 	settings["{uniqueID}"] = {
-		topic: topic
+		topic: topic,
+		color: colourpicker.value,
 	}
 	settings.save();
 }
@@ -39,7 +46,7 @@ function drawPath(){
 		return;
 
 	ctx.lineWidth = 2;
-	ctx.strokeStyle = "#5ED753";
+	ctx.strokeStyle = colourpicker.value;
 	ctx.beginPath();
 
 	pose_array.forEach((point, index) => {
@@ -85,7 +92,8 @@ function connect(){
 	path_topic = new ROSLIB.Topic({
 		ros : rosbridge.ros,
 		name : topic,
-		messageType : 'nav_msgs/Path'
+		messageType : 'nav_msgs/Path',
+		compression: "cbor"		
 	});
 	
 	listener = path_topic.subscribe((msg) => {

--- a/public/templates/posearray/posearray_script.js
+++ b/public/templates/posearray/posearray_script.js
@@ -105,7 +105,8 @@ function connect(){
 		ros : rosbridge.ros,
 		name : topic,
 		messageType : 'geometry_msgs/PoseArray',
-		throttle_rate: 50
+		throttle_rate: 50,
+		compression: "cbor"
 	});
 	
 	listener = poses_topic.subscribe((msg) => {

--- a/public/templates/scan/scan_script.js
+++ b/public/templates/scan/scan_script.js
@@ -136,7 +136,8 @@ function connect(){
 		ros : rosbridge.ros,
 		name : topic,
 		messageType : 'sensor_msgs/LaserScan',
-		throttle_rate: parseInt(throttle.value)
+		throttle_rate: parseInt(throttle.value),
+		compression: "cbor"
 	});
 	
 	listener = range_topic.subscribe((msg) => {	

--- a/public/templates/teleop/teleop_script.js
+++ b/public/templates/teleop/teleop_script.js
@@ -115,6 +115,7 @@ function connect(){
 		ros: rosbridge.ros,
 		name: topic,
 		messageType: 'geometry_msgs/Twist',
+		queue_size: 1
 	});
 }
 

--- a/public/templates/temperature/temperature_script.js
+++ b/public/templates/temperature/temperature_script.js
@@ -110,4 +110,4 @@ icon.addEventListener("click", (event) => {
 
 loadTopics();
 
-console.log("Temeprature Widget Loaded {uniqueID}")
+console.log("Temperature Widget Loaded {uniqueID}")


### PR DESCRIPTION
I've added [CBOR compression](https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/ROSBRIDGE_PROTOCOL.md#313-cbor-encoding--cbor-)  for the more data heavy visualizers, except for compressedimage since it seems to actually replace jpeg in that case, which breaks rendering.

The Empty button is now gray by default for better contrast, and Temperature topics should now show up in the topics tab.