### PR TITLE
Reliability patches

### DIFF
--- a/public/js/lib/nipplejs_LICENSE.txt
+++ b/public/js/lib/nipplejs_LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Yoann Moinet <yoann.moinet@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/public/js/lib/quaternionjs_LICENSE.txt
+++ b/public/js/lib/quaternionjs_LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Robert Eisele
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/public/js/lib/roslibjs_LICENSE.txt
+++ b/public/js/lib/roslibjs_LICENSE.txt
@@ -1,0 +1,32 @@
+Software License Agreement (BSD License)
+
+Copyright (c) 2014, Worcester Polytechnic Institute, Robert Bosch
+LLC, Yujin Robot. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+ * Neither the name of Worcester Polytechnic Institute, Robert
+   Bosch LLC, Yujin Robot nor the names of its contributors may be
+   used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/public/js/modules/elements.js
+++ b/public/js/modules/elements.js
@@ -1,10 +1,7 @@
-export const elementTemplatesPromise = loadElementTemplates();
+import fileList from '/templates/files' assert {type: 'json'};
 
 async function loadElementTemplates() {
-    let templates = {};
-
-    const fileListResponse = await fetch('/templates/files');
-    const fileList = await fileListResponse.json();
+    let templates = {};    
 
     const fetchPromises = fileList.map(async file => {
         const filePathParts = file.split('/');
@@ -27,3 +24,5 @@ async function loadElementTemplates() {
 
     return templates;
 }
+
+export const elementTemplatesPromise = loadElementTemplates();

--- a/public/js/modules/rosbridge.js
+++ b/public/js/modules/rosbridge.js
@@ -9,6 +9,8 @@ class Rosbridge {
 
 		this.connect();
 		this.status = "Connecting...";
+
+		this.reset_reconnect = false;
 	}
 
 	connect(){
@@ -24,6 +26,10 @@ class Rosbridge {
 			this.connected = true;
 			this.status = "Connected.";
 
+			if(this.reset_reconnect){
+				location.reload(false); //otherwise topics won't re-subscribe automatically :/
+			}
+
 			window.dispatchEvent(new Event('rosbridge_change'));
 		});
 
@@ -36,6 +42,7 @@ class Rosbridge {
 		this.ros.on('close', () => {
 			this.connected = false;
 			this.status = "Connection lost.";
+			this.reset_reconnect = true;
 			window.dispatchEvent(new Event('rosbridge_change'));
 
 			setTimeout(() => {

--- a/public/js/modules/util.js
+++ b/public/js/modules/util.js
@@ -8,3 +8,24 @@ export async function toDataURL(url) {
 		reader.readAsDataURL(blob);
 	});
 }
+
+//webkit http compatible fetch-free implementation
+export function imageToDataURL(url) {
+	return new Promise((resolve, reject) => {
+		const img = new Image();		
+		img.onload = () => {
+			const canvas = document.createElement("canvas");
+			canvas.width = img.width;
+			canvas.height = img.height;
+
+			const ctx = canvas.getContext("2d");
+			ctx.drawImage(img, 0, 0);
+
+			const dataURL = canvas.toDataURL();
+			resolve(dataURL);
+		};
+		img.onerror = reject;
+		img.src = url;
+	});
+}
+  

--- a/public/templates/button/button_script.js
+++ b/public/templates/button/button_script.js
@@ -7,9 +7,9 @@ let typedict = {};
 
 //persistent loading, so we don't re-fetch on every update
 let icons = {};
-icons["false"] = await imageToDataURL("assets/button_true.svg");
-icons["true"] = await imageToDataURL("assets/button_false.svg");
-icons["default"] = await imageToDataURL("assets/button_false.svg");
+icons["true"] = await imageToDataURL("assets/button_true.svg");
+icons["false"] = await imageToDataURL("assets/button_false.svg");
+icons["default"] = await imageToDataURL("assets/button.svg");
 
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const icondiv = document.getElementById("{uniqueID}_icon");

--- a/public/templates/button/button_script.js
+++ b/public/templates/button/button_script.js
@@ -1,8 +1,15 @@
 import { rosbridge } from '/js/modules/rosbridge.js';
 import { settings } from '/js/modules/persistent.js';
+import { imageToDataURL } from '/js/modules/util.js';
 
 let topic = getTopic("{uniqueID}");
 let typedict = {};
+
+//persistent loading, so we don't re-fetch on every update
+let icons = {};
+icons["false"] = await imageToDataURL("assets/button_true.svg");
+icons["true"] = await imageToDataURL("assets/button_false.svg");
+icons["default"] = await imageToDataURL("assets/button_false.svg");
 
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const icondiv = document.getElementById("{uniqueID}_icon");
@@ -76,13 +83,13 @@ function connect(){
 		
 		listener = booltopic.subscribe((msg) => {
 			value = msg.data;
-			icon.src = "assets/button_"+value+".svg";
+			icon.src = icons[value];
 		});
 
-		icon.src = "assets/button_false.svg";
+		icon.src = icons["false"];
 	}
 	else{
-		icon.src = "assets/button.svg";
+		icon.src = icons["default"];
 	}
 
 	
@@ -119,7 +126,7 @@ async function loadTopics(){
 
 selectionbox.addEventListener("change", (event) => {
 	topic = selectionbox.value;
-	icon.src = "assets/button.svg";
+	icon.src = icons["default"];
 	connect();
 });
 

--- a/public/templates/compressedimage/compressedimage_script.js
+++ b/public/templates/compressedimage/compressedimage_script.js
@@ -1,10 +1,16 @@
 import { rosbridge } from '/js/modules/rosbridge.js';
 import { settings } from '/js/modules/persistent.js';
+import { imageToDataURL } from '/js/modules/util.js';
 
 let img_offset_x = "0%";
 let img_offset_y = "75px";
 
 let topic = getTopic("{uniqueID}");
+
+//persistent loading, so we don't re-fetch on every update
+let stock_images = {};
+stock_images["loading"] = await imageToDataURL("assets/tile_loading.png");
+stock_images["error"] = await imageToDataURL("assets/tile_error.png");
 
 let image_topic = undefined;
 let listener = undefined;
@@ -98,7 +104,7 @@ async function getImage(src) {
 
 function connect(){
 
-	canvas.src = "assets/tile_loading.png";
+	canvas.src = stock_images["loading"];
 
 	if(topic == "")
 		return;
@@ -122,7 +128,7 @@ function connect(){
 				canvas.src = src;
 			})
 			.catch(() => {
-				canvas.src = "assets/tile_error.png";
+				canvas.src = stock_images["error"];
 			});
 	});
 

--- a/public/templates/robotmodel/robotmodel_script.js
+++ b/public/templates/robotmodel/robotmodel_script.js
@@ -1,11 +1,9 @@
 import { view } from '/js/modules/view.js';
 import { tf } from '/js/modules/tf.js';
 import { settings } from '/js/modules/persistent.js';
+import fileList from '/assets/robot_model/files' assert {type: 'json'};
 
 let models = {};
-
-const fileListResponse = await fetch('/assets/robot_model/files');
-const fileList = await fileListResponse.json();
 fileList.map(file => {
 	const name = file.split('.png')[0].split("_")[1];
 	models[name] = new Image();

--- a/public/templates/rosbridge/rosbridge_script.js
+++ b/public/templates/rosbridge/rosbridge_script.js
@@ -1,23 +1,14 @@
 import { rosbridge } from '/js/modules/rosbridge.js';
+import { imageToDataURL } from '/js/modules/util.js';
 
 let url = document.getElementById("{uniqueID}_url");
 let statustext = document.getElementById("{uniqueID}_status");
 let icon = document.getElementById("{uniqueID}_icon").getElementsByTagName('img')[0];
 
-async function urlToBase64(url) {
-	const response = await fetch(url);
-	const blob = await response.blob();
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onloadend = () => resolve(reader.result);
-		reader.onerror = reject;
-		reader.readAsDataURL(blob);
-	});
-}
-
-let img_reconnect = await urlToBase64('assets/rosbridge_reconnect.svg');
-let img_connect = await urlToBase64('assets/rosbridge_connected.svg');
-let img_disconnect = await urlToBase64('assets/rosbridge_disconnected.svg');
+// can't show images about reconnecting without preloading them before we lose connection
+let img_reconnect = await imageToDataURL('assets/rosbridge_reconnect.svg');
+let img_connect = await imageToDataURL('assets/rosbridge_connected.svg');
+let img_disconnect = await imageToDataURL('assets/rosbridge_disconnected.svg');
 
 function update_gui(){
 	url.innerText = "Bridge URL: ws://"+rosbridge.url + ":"+rosbridge.port;

--- a/public/templates/temperature/temperature_script.js
+++ b/public/templates/temperature/temperature_script.js
@@ -1,16 +1,17 @@
 import { rosbridge } from '/js/modules/rosbridge.js';
 import { settings } from '/js/modules/persistent.js';
-import { toDataURL } from '/js/modules/util.js';
+import { imageToDataURL } from '/js/modules/util.js';
 
 let topic = getTopic("{uniqueID}");
 let listener = undefined;
 let temperature_topic = undefined;
 
+//persistent loading, so we don't re-fetch on every update
 let icons = {};
-icons["hot"] = await toDataURL("assets/temp_hot.svg");
-icons["cold"] = await toDataURL("assets/temp_cold.svg");
-icons["warm"] = await toDataURL("assets/temp_warm.svg");
-icons["unknown"] = await toDataURL("assets/temp_warm.svg");
+icons["hot"] = await imageToDataURL("assets/temp_hot.svg");
+icons["cold"] = await imageToDataURL("assets/temp_cold.svg");
+icons["warm"] = await imageToDataURL("assets/temp_warm.svg");
+icons["unknown"] = await imageToDataURL("assets/temp_warm.svg");
 
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const icon = document.getElementById("{uniqueID}_icon").getElementsByTagName('img')[0];


### PR DESCRIPTION
Fixed some problems with image caching, so icons don't need to be fetched from the server when changed and won't become broken if connection is spotty.  Some fetch calls have been replaced with imports which may be compatible with webkit over http, but needs testing. I've also added some missing dep licenses.

Rosbridge should also connect topics after reconnecting properly now (page soft reload workaround 😄 ).

