### PR TITLE
Add contanerization option for running system

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -27,7 +27,7 @@ Flask and Jinja2 are used for templating, rosbridge is required for socket commu
 
 ### Docker
 
-To launch Vizanti hosted in a container, first you need to build the container. This assumes you have docker installed, if not, navigate here [Docker](https://docs.docker.com/engine/install/ubuntu/).
+Alternativelly, you can also containerize Vizanti. For that you need to [install Docker](https://docs.docker.com/engine/install/ubuntu/) and build the container:
 
 ```bash
 git clone https://github.com/MoffKalast/vizanti.git
@@ -36,13 +36,11 @@ docker build -f docker/Dockerfile -t vizanti:1.0 .
 ```
 
 ## Run
-
-### Directly  
+  
 ```bash
 roslaunch vizanti server.launch
 ```  
-
-### Docker  
+Or with Docker:
 ```bash
 docker run -dit --net=host --name vizanti-noetic vizanti:1.0
 ```  

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -44,7 +44,7 @@ roslaunch vizanti server.launch
 
 ### Docker  
 ```bash
-docker run -dit --net=host vizanti:1.0
+docker run -dit --net=host --name vizanti-noetic vizanti:1.0
 ```  
 
 The web app can be accessed at `http://<host_ip>:5000`. Client settings are automatically saved in localStorage. The satelite imagery renderer also uses the indexedDB to store tiles for offline use (note that this is IP specific). By default the rosbridge instance also occupies port 5001.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,14 +20,14 @@ catkin_make
 
 Or if rosdep fails for some reason, these are the main two deps:
 ```
-sudo apt install ros-noetic-rosbridge-suite python3-flask
+sudo apt install ros-noetic-rosbridge-suite ros-noetic-move-base-msgs python3-flask
 ```
 
 Flask and Jinja2 are used for templating, rosbridge is required for socket communication.
 
 ### Docker
 
-To launch Vizanti hosted in a container, first you need to build the container. Assume you have docker installed, if not, navigat here [Docker](https://docs.docker.com/engine/install/ubuntu/).
+To launch Vizanti hosted in a container, first you need to build the container. This assumes you have docker installed, if not, navigate here [Docker](https://docs.docker.com/engine/install/ubuntu/).
 
 ```bash
 git clone https://github.com/MoffKalast/vizanti.git

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -10,7 +10,7 @@ Vizanti is a web-based visualization and control tool developed for more conveni
 
 As a field tool, Vizanti is designed to operate just as well without internet access, and as such the intended way is to host it on a robot, with rosbridge autoconnecting to the host IP. 
 
- ```bash
+```bash
 cd ~/catkin_ws/src
 git clone https://github.com/MoffKalast/vizanti.git
 cd ..
@@ -22,13 +22,31 @@ Or if rosdep fails for some reason, these are the main two deps:
 ```
 sudo apt install ros-noetic-rosbridge-suite python3-flask
 ```
- 
+
 Flask and Jinja2 are used for templating, rosbridge is required for socket communication.
 
+### Docker
+
+To launch Vizanti hosted in a container, first you need to build the container. Assume you have docker installed, if not, navigat here [Docker](https://docs.docker.com/engine/install/ubuntu/).
+
+```bash
+git clone https://github.com/MoffKalast/vizanti.git
+cd vizanti
+docker build -f docker/Dockerfile -t vizanti:1.0 .
+```
+
 ## Run
+
+### Directly  
 ```bash
 roslaunch vizanti server.launch
-```
+```  
+
+### Docker  
+```bash
+docker run -dit --net=host vizanti:1.0
+```  
+
 The web app can be accessed at `http://<host_ip>:5000`. Client settings are automatically saved in localStorage. The satelite imagery renderer also uses the indexedDB to store tiles for offline use (note that this is IP specific). By default the rosbridge instance also occupies port 5001.
 
 If you're using a mobile device connected to a robot's hotspot that doesn't have internet access, make sure to turn off mobile data. This will prevent Android from sending packets to the wrong gateway.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM osrf/ros:noetic-desktop
+
+SHELL ["/bin/bash", "-c"]
+
+# Update and build the vizanti package
+RUN apt-get update
+RUN useradd -ms /bin/bash vizanti
+RUN mkdir -p /home/vizanti/catkin_ws/src
+COPY . /home/vizanti/catkin_ws/src/vizanti/.
+RUN apt install ros-noetic-rosbridge-suite ros-noetic-move-base-msgs python3-flask -y
+RUN source /opt/ros/noetic/setup.bash && cd /home/vizanti/catkin_ws && catkin_make
+
+USER vizanti
+# Launch Vizanti
+CMD source /home/vizanti/catkin_ws/devel/setup.bash && roslaunch vizanti server.launch


### PR DESCRIPTION
This runs Vizanti in a container. Readme is updated on how to build and launch the docker container.

Briefly tested, communication works both directions.

