### PR TITLE
Waypoints demo node (Noetic)

### DIFF
--- a/public/templates/waypoints/waypoints_script.js
+++ b/public/templates/waypoints/waypoints_script.js
@@ -159,7 +159,7 @@ function sendMessage(pointlist){
 					p1 = point;
 				}
 
-				const rotation = Quaternion.fromEuler(Math.atan2(p0.y - p1.y, -(p0.x - p1.x)), 0, 0, 'ZXY');
+				const rotation = Quaternion.fromEuler(Math.atan2(p1.y - p0.y, p1.x - p0.x), 0, 0, 'ZXY');
 
 				if(stamped){
 					poseList.push(getPoseStamped(index, timeStamp, point.x, point.y, rotation));

--- a/scripts/waypoints_to_simple_goals.py
+++ b/scripts/waypoints_to_simple_goals.py
@@ -48,7 +48,14 @@ class WaypointsToSimpleGoals:
 		rospy.loginfo("Waypoints node started.")
 
 	def waypoints_callback(self, msg):
-		self.waypoints = list(msg.poses)
+		poses = list(msg.poses)
+
+		if len(poses) == 0:
+			#Empty array was sent as a preempt, we should just abort current execution
+			self.estop_callback(None)
+			return
+
+		self.waypoints = poses
 		self.waypoints_header = msg.header
 		self.current_goal = None
 		rospy.loginfo("New path received!")

--- a/scripts/waypoints_to_simple_goals.py
+++ b/scripts/waypoints_to_simple_goals.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+import math
+import rospy
+import tf2_ros
+
+from geometry_msgs.msg import PoseArray, PoseStamped, Pose
+from std_msgs.msg import Bool, Empty
+
+"""
+Since many navigations stacks do not support multiple goals or even action servers,
+this node serves is a demo example of sending simple goals sequentially, checking for range completion in between.
+Goal timeouts and handling other edge cases is left as an excercise to the reader.
+"""
+
+class WaypointsToSimpleGoals:
+	def __init__(self):
+		rospy.init_node('waypoints_to_simple_goals')
+		
+		self.rate = rospy.get_param('~rate', 10)
+		self.robot_link = rospy.get_param('~robot_link', 'base_link')
+		self.goal_reached_range = rospy.get_param('~goal_reached_range', 0.1)
+		
+		# State management through waypoints list
+		self.waypoints = []
+		self.current_goal = None
+		self.waypoints_header = None
+
+		self.last_robot_pose = None
+		self.tf_buffer = tf2_ros.Buffer()
+		self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
+		
+		# Remap this if your nav stack takes simple goals on another topic
+		self.goal_pub = rospy.Publisher('/move_base_simple/goal', PoseStamped, queue_size=1)
+
+		# Sends out the current navigation state (active/idle)
+		self.state_pub = rospy.Publisher('/waypoints/state', Bool, queue_size=1, latch=True)
+		
+		# Point the Waypoints widget to this one
+		self.waypoints_sub = rospy.Subscriber('/waypoints', PoseArray, self.waypoints_callback)
+
+		# Point a Button widget to this one to stop path execution at any time
+		self.estop_sub = rospy.Subscriber('/waypoints/estop', Empty, self.estop_callback)
+		
+		# Initialize state
+		self.publish_navigation_state(False)
+		
+		rospy.loginfo("Waypoints node started.")
+
+	def waypoints_callback(self, msg):
+		self.waypoints = list(msg.poses)
+		self.waypoints_header = msg.header
+		self.current_goal = None
+		rospy.loginfo("New path received!")
+
+	def estop_callback(self, _):
+		if self.current_goal is not None and self.last_robot_pose is not None and self.waypoints_header is not None:
+			goal = PoseStamped()
+			goal.header = self.waypoints_header
+			goal.pose = self.last_robot_pose
+			self.goal_pub.publish(goal)
+
+		self.waypoints = []
+		self.current_goal = None
+		self.publish_navigation_state(False)
+
+		rospy.loginfo("Emergency stop triggered!")
+
+	def update(self):
+		if not self.waypoints:
+			if self.current_goal is not None:
+				self.current_goal = None
+				self.publish_navigation_state(False)
+			return
+
+		# Send next goal
+		if self.current_goal is None and self.waypoints:
+			
+			next_pose = self.waypoints[0]
+			
+			goal = PoseStamped()
+			goal.header = self.waypoints_header
+			goal.pose = next_pose
+			self.goal_pub.publish(goal)
+			
+			self.current_goal = goal
+			self.publish_navigation_state(True)
+			rospy.loginfo(f"Published: ({next_pose.position.x},{next_pose.position.y},{next_pose.position.z}), {len(self.waypoints)} goals left.")
+
+		# Check if current goal is reached
+		if self.current_goal and self.check_goal_reached(self.current_goal):
+			self.waypoints.pop(0)
+			self.current_goal = None
+
+			if not self.waypoints:
+				rospy.loginfo("Path finished!")
+
+	def check_goal_reached(self, goal):
+		try:
+			transform = self.tf_buffer.lookup_transform(
+				goal.header.frame_id,
+				self.robot_link,
+				rospy.Time(0),  # get most recent transform
+				rospy.Duration(1.0)
+			)
+
+			self.last_robot_pose = Pose()
+			self.last_robot_pose.position = transform.transform.translation
+			self.last_robot_pose.orientation = transform.transform.rotation
+
+			dx = transform.transform.translation.x - goal.pose.position.x
+			dy = transform.transform.translation.y - goal.pose.position.y
+			distance = math.sqrt(dx*dx + dy*dy)
+
+			return distance <= self.goal_reached_range
+
+		except (tf2_ros.LookupException, 
+				tf2_ros.ConnectivityException,
+				tf2_ros.ExtrapolationException) as e:
+			return False
+
+	def publish_navigation_state(self, state):
+		self.state_pub.publish(Bool(data=state))
+
+	def cleanup(self):
+		self.waypoints = []
+		self.current_goal = None
+		self.publish_navigation_state(False)
+
+node = WaypointsToSimpleGoals()
+rate = rospy.Rate(node.rate)
+rospy.on_shutdown(node.cleanup)
+
+while not rospy.is_shutdown():
+	node.update()
+	rate.sleep()


### PR DESCRIPTION
A simple node for testing the waypoints widget on nav stacks with only simple goal support. #133

## Waypoints to Simple Goals Node

A ROS node that converts a sequence of waypoints into individual navigation goals, sending them sequentially as PoseStamped simple goals, and monitors the robot's progress. Designed for navigation stacks that don't natively support multiple goals or action servers.

### Parameters  
- **`~rate`** (float, default: 10.0) – Update rate in Hz for goal checking.  
- **`~robot_link`** (string, default: "base_link") – TF frame of the robot base, used for goal checking.  
- **`~goal_reached_range`** (float, default: 0.1) – Distance in meters to consider a goal reached, must be greater than or equal to the navigation's setting.  

### Subscribers  
- **`/waypoints`** (`geometry_msgs/PoseArray`) – Send a path from the Waypoints widget to this topic.  
- **`/waypoints/estop`** (`std_msgs/Empty`) – Emergency stop trigger: stops waypoint following and sends the robot's current position as a goal to stop the planner. Can be used with the Button widget.  

### Publishers  
- **`/move_base_simple/goal`** (`geometry_msgs/PoseStamped`) – Publishes individual navigation goals. Remap to whatever `PoseStamped` topic your navigation stack uses.  
- **`/waypoints/state`** (`std_msgs/Bool`) – Latched topic indicating if waypoints are being followed (`True = active`, `False = idle`). Can be used with the Button widget.  

### Run

`rosrun vizanti waypoints_to_simple_goals.py`