### PR TITLE
Waypoints demo node (ROS 2)

### DIFF
--- a/vizanti_demos/CMakeLists.txt
+++ b/vizanti_demos/CMakeLists.txt
@@ -36,6 +36,7 @@ install(PROGRAMS
   scripts/test_grid_cells.py
   scripts/test_marker_array.py
   scripts/test_tf.py
+  scripts/waypoints_to_simple_goals.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/vizanti_demos/scripts/waypoints_to_simple_goals.py
+++ b/vizanti_demos/scripts/waypoints_to_simple_goals.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+
+import math
+import rclpy
+import tf2_ros
+
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+from rcl_interfaces.msg import SetParametersResult
+
+from geometry_msgs.msg import PoseArray, PoseStamped, Pose
+from std_msgs.msg import Bool, Empty
+from tf2_ros import TransformListener, Buffer
+
+"""
+Since navigate_through_poses is still a bit unreliable,
+this node serves is a demo example of sending simple goals sequentially,
+checking for range completion in between.
+Goal timeouts and handling other edge cases is left as an excercise to the reader.
+"""
+
+class WaypointsToSimpleGoals(Node):
+    def __init__(self):
+        super().__init__('waypoints_to_simple_goals')
+
+        self.declare_parameter('rate', 10)
+        self.declare_parameter('robot_link', 'base_link')
+        self.declare_parameter('goal_reached_range', 0.3)
+
+        self.rate = self.get_parameter('rate').get_parameter_value().integer_value
+        self.robot_link = self.get_parameter('robot_link').get_parameter_value().string_value
+        self.goal_reached_range = self.get_parameter('goal_reached_range').get_parameter_value().double_value
+
+        self.waypoints = []
+        self.current_goal = None
+        self.waypoints_header = None
+        self.last_robot_pose = None
+
+        self.tf_buffer = Buffer()
+        self.tf_listener = TransformListener(self.tf_buffer, self)
+
+        self.goal_pub = self.create_publisher(PoseStamped, '/goal_pose', 10)
+        self.state_pub = self.create_publisher(Bool, '/waypoints/state', 10)
+        
+        self.create_subscription(PoseArray, '/waypoints', self.waypoints_callback, 10)
+        self.create_subscription(Empty, '/waypoints/estop', self.estop_callback, 10)
+
+        self.add_on_set_parameters_callback(self.parameters_callback)
+
+        self.publish_navigation_state(False)
+        self.get_logger().info("Waypoints node started.")
+
+        self.timer = self.create_timer(1.0 / self.rate, self.update)
+
+    def parameters_callback(self, params):
+
+        for param in params:
+            if param.name == "robot_link":
+                self.robot_link = param.value
+            elif param.name == "goal_reached_range":
+                self.goal_reached_range = param.value
+
+        return SetParametersResult(successful=True)
+
+    def waypoints_callback(self, msg):
+        poses = list(msg.poses)
+        
+        if not poses:
+            self.estop_callback(None)
+            return
+
+        self.waypoints = poses
+        self.waypoints_header = msg.header
+        self.current_goal = None
+        self.get_logger().info("New path received!")
+
+    def estop_callback(self, _):
+        if self.current_goal and self.last_robot_pose and self.waypoints_header:
+            goal = PoseStamped()
+            goal.header = self.waypoints_header
+            goal.pose = self.last_robot_pose
+            self.goal_pub.publish(goal)
+
+        self.waypoints = []
+        self.current_goal = None
+        self.publish_navigation_state(False)
+
+        self.get_logger().info("Emergency stop triggered!")
+
+    def update(self):
+        if not self.waypoints:
+            if self.current_goal is not None:
+                self.current_goal = None
+                self.publish_navigation_state(False)
+            return
+
+        if self.current_goal is None and self.waypoints:
+            next_pose = self.waypoints[0]
+
+            goal = PoseStamped()
+            goal.header = self.waypoints_header
+            goal.pose = next_pose
+            self.goal_pub.publish(goal)
+
+            self.current_goal = goal
+            self.publish_navigation_state(True)
+            self.get_logger().info(f"Published: ({next_pose.position.x},{next_pose.position.y},{next_pose.position.z}), {len(self.waypoints)} goals left.")
+
+        if self.current_goal and self.check_goal_reached(self.current_goal):
+            self.waypoints.pop(0)
+            self.current_goal = None
+
+            if not self.waypoints:
+                self.get_logger().info("Path finished!")
+
+    def check_goal_reached(self, goal):
+        try:
+            transform = self.tf_buffer.lookup_transform(
+                goal.header.frame_id,
+                self.robot_link,
+                rclpy.time.Time()
+            )
+
+            pos = transform.transform.translation
+
+            self.last_robot_pose = Pose()
+            self.last_robot_pose.position.x = pos.x
+            self.last_robot_pose.position.y = pos.y
+            self.last_robot_pose.position.z = pos.y
+            self.last_robot_pose.orientation = transform.transform.rotation
+
+            dx = pos.x - goal.pose.position.x
+            dy = pos.y - goal.pose.position.y
+            distance = math.sqrt(dx * dx + dy * dy)
+
+            return distance <= self.goal_reached_range
+        except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException):
+            return False
+
+    def publish_navigation_state(self, state):
+        self.state_pub.publish(Bool(data=state))
+
+    def cleanup(self):
+        self.waypoints = []
+        self.current_goal = None
+        self.publish_navigation_state(False)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = WaypointsToSimpleGoals()
+    rclpy.spin(node)
+    node.cleanup()
+    node.destroy_node()
+    rclpy.shutdown()
+
+if __name__ == "__main__":
+    main()

--- a/vizanti_server/public/templates/waypoints/waypoints_script.js
+++ b/vizanti_server/public/templates/waypoints/waypoints_script.js
@@ -157,7 +157,7 @@ function sendMessage(pointlist){
 					p1 = point;
 				}
 
-				const rotation = Quaternion.fromEuler(Math.atan2(p0.y - p1.y, -(p0.x - p1.x)), 0, 0, 'ZXY');
+				const rotation = Quaternion.fromEuler(Math.atan2(p1.y - p0.y, p1.x - p0.x), 0, 0, 'ZXY');
 
 				if(stamped){
 					poseList.push(getPoseStamped(index, timeStamp, point.x, point.y, rotation));


### PR DESCRIPTION
Upstreaming #134 since giving Nav2 simple goals seems to work far more reliably than navigate_through_poses at the moment. Addresses some issues from #111



![image](https://github.com/user-attachments/assets/22eee010-5da4-4af5-8a99-c86deaa43b4c)

## Waypoints to Simple Goals Node

A ROS 2 node that converts a sequence of waypoints into individual navigation goals, sending them sequentially as PoseStamped simple goals, and monitors the robot's progress.

### Parameters  
- **`~rate`** (float, default: 10.0) – Update rate in Hz for goal checking. Can't be reconfigured later.
- **`~robot_link`** (string, default: "base_link") – TF frame of the robot base, used for goal checking. 
- **`~goal_reached_range`** (float, default: 0.3) – Distance in meters to consider a goal reached, must be greater than or equal to the navigation's setting.  

### Subscribers  
- **`/waypoints`** (`geometry_msgs/PoseArray`) – Send a path from the Waypoints widget to this topic.  
- **`/waypoints/estop`** (`std_msgs/Empty`) – Emergency stop trigger: stops waypoint following and sends the robot's current position as a goal to stop the planner. Can be used with the Button widget.  

### Publishers  
- **`/goal_pose`** (`geometry_msgs/PoseStamped`) – Publishes individual navigation goals. Remap to whatever `PoseStamped` topic your navigation stack uses.  
- **`/waypoints/state`** (`std_msgs/Bool`) – Latched topic indicating if waypoints are being followed (`True = active`, `False = idle`). Can be used with the Button widget.  

### Run

`ros2 run vizanti_demos waypoints_to_simple_goals.py`
