### PR TITLE
Modal consistency, PoseStamped axes render mode

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,7 +12,7 @@ As a field tool, Vizanti is designed to operate just as well without internet ac
 
 ```bash
 cd ~/catkin_ws/src
-git clone https://github.com/MoffKalast/vizanti.git
+git clone -b noetic-devel https://github.com/MoffKalast/vizanti.git
 cd ..
 rosdep install -i --from-path src/vizanti -y
 catkin_make
@@ -23,7 +23,7 @@ catkin_make
 Alternatively, you can also containerize Vizanti. For that you need to [install Docker](https://docs.docker.com/engine/install/ubuntu/) and build the container:
 
 ```bash
-git clone https://github.com/MoffKalast/vizanti.git
+git clone -b noetic-devel https://github.com/MoffKalast/vizanti.git
 cd vizanti
 docker build -f docker/Dockerfile -t vizanti:1.0 .
 ```

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -43,7 +43,7 @@ h1, h2, h3, b, p {
 }
 
 .dark_hr{
-	border: 1px solid rgba(128, 128, 128, 0.5);
+	border: 1px solid rgba(160, 160, 160, 0.6);
 }
 
 a {
@@ -458,10 +458,12 @@ input[type=text] {
 	font-family: 'Ubuntu Mono', Monospace;
 }
 
-br {
-	content: "";
+.spacer {
 	display: block;
-	margin-bottom: 1rem;
+	height: 0.8rem;      /* Adjust for desired spacing */
+	line-height: 1;    /* Prevent line-height inflation */
+	margin: 0;         /* Remove default div margin */
+	padding: 0;
 }
 
 input[type="checkbox"] {

--- a/public/js/modules/tf.js
+++ b/public/js/modules/tf.js
@@ -277,8 +277,8 @@ export class TF {
 
 	transformPose(sourceFrame, targetFrame, inputVector, inputQuat) {
 
-		let outputVector =  Object.assign({}, inputVector);
-		let outputQuat =  new Quaternion(inputQuat);
+		let outputVector = Object.assign({}, inputVector);
+		let outputQuat = new Quaternion(inputQuat);
 
 		if(sourceFrame == targetFrame){
 			return {

--- a/public/templates/add/add_modal.html
+++ b/public/templates/add/add_modal.html
@@ -2,7 +2,7 @@
 	<div class="modal_inner noselect">
 		<h3>Add Widgets</h3>
 		
-		<br>
+		<div class="spacer"></div>
 
 		<div class="tab">
 			<button class="tablinks active_tab" id="add_set_type">By Type</button>

--- a/public/templates/altimeter/altimeter_modal.html
+++ b/public/templates/altimeter/altimeter_modal.html
@@ -7,14 +7,14 @@
 	<div class="modal_inner noselect">
 		<h3>Altimeter</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_frame">Robot Frame:</label>
 		<select id="{uniqueID}_frame" name="topic">
 			<option value='base_link'>base_link</option>
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_mode">Display Mode:</label>
 		<select id="{uniqueID}_mode" name="topic">
@@ -24,12 +24,12 @@
 			<option value='depth_positive'>Depth inverted (Z+)</option>
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_step">Step (meter):</label>
 		<input type="number" value="1.0" step="0.1" min="0.1" max="1000" id="{uniqueID}_step">
 
-		<br>
+		<div class="spacer"></div>
 
 		<div class="live_data_display">
 			<p id="{uniqueID}_altitude_text">Altitude: ?</p>
@@ -38,11 +38,11 @@
 
 		Displays the Z value of the frame on a depth/altitude gauge. Inverted modes treat negative values to positive.
 
-		<br>
+		<div class="spacer"></div>
 
 		<h4>Send Target</h4>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_topic">Value Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
@@ -55,9 +55,9 @@
 
 		<button id="{uniqueID}_manual_target" class="export_button">Input and send target manually</button>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/area/area_modal.html
+++ b/public/templates/area/area_modal.html
@@ -2,7 +2,7 @@
 	<div class="modal_inner noselect">
 		<h3>Area</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
@@ -13,9 +13,9 @@
 
 		<p class="comment">Click the icon once to enable, drag on the view area and release to publish. Long press the icon to open this menu.</p>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/battery/battery_modal.html
+++ b/public/templates/battery/battery_modal.html
@@ -1,8 +1,11 @@
 <div id="{uniqueID}_modal" class="modal_outer noselect">
 	<div class="modal_inner noselect">
 		<h3>Battery Info</h3>
+		
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+
+		<hr class="dark_hr"/>
+
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
@@ -23,9 +26,9 @@
 
 		<p>Read and display battery data from sensor_msgs/BatteryState messages.</p>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/battery/battery_script.js
+++ b/public/templates/battery/battery_script.js
@@ -150,8 +150,6 @@ function connect(){
 			text_cell_voltage.innerText = cellstr.substring(0, cellstr.length - 2);
 		}
 
-
-
 		text_status.innerText = "Status: "+STATUS[msg.power_supply_status];
 		text_health.innerText = "Health: "+HEALTH[msg.power_supply_health];
 		text_chemistry.innerText = "Type: "+CHEMISTRY[msg.power_supply_technology];

--- a/public/templates/button/button_modal.html
+++ b/public/templates/button/button_modal.html
@@ -1,19 +1,22 @@
 <div id="{uniqueID}_modal" class="modal_outer noselect">
 	<div class="modal_inner noselect">
 		<h3>Button</h3>
+		
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_name">Display Text:</label>
 		<input id="{uniqueID}_name" type="text" value="Text">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
 		</select>
-		<hr>
+
+		<hr class="dark_hr"/>
 
 		<p>Multifunctional button. Behavior depends on the selected topic/service type:</p>
 		<ul>
@@ -27,7 +30,7 @@
 
 		<p style="color:#b4b4b4;">Click the icon to trigger. Long press to reopen this menu.</p>
 		
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/button/button_script.js
+++ b/public/templates/button/button_script.js
@@ -69,6 +69,7 @@ function sendMessage(){
 			ros: rosbridge.ros,
 			name: topic,
 			messageType: typedict[topic],
+			throttle_rate: 33
 		});
 
 		if(typedict[topic] == "std_msgs/Bool"){
@@ -148,7 +149,8 @@ function connect(){
 		booltopic = new ROSLIB.Topic({
 			ros : rosbridge.ros,
 			name : topic,
-			messageType : "std_msgs/Bool"
+			messageType : "std_msgs/Bool",
+			throttle_rate: 33
 		});	
 		
 		listener = booltopic.subscribe((msg) => {

--- a/public/templates/compressedimage/compressedimage_modal.html
+++ b/public/templates/compressedimage/compressedimage_modal.html
@@ -8,14 +8,14 @@
 	<div class="modal_inner noselect">
 		<h3>Compressed Image</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_rotation">Rotation:</label>
 		<select id="{uniqueID}_rotation" name="rotation">
@@ -25,30 +25,30 @@
 			<option value="270">270 degrees</option>
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_opacity">Opacity:</label>
 		<span id="{uniqueID}_opacity_value">0.85</span>
 		<input type="range" value="0.85" step="0.05" min="0.1" max="1.0" id="{uniqueID}_opacity">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_width">Width (screen %):</label>
 		<span id="{uniqueID}_width_value">25</span>
 		<input type="range" value="25" step="1" min="5" max="100" id="{uniqueID}_width">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
 		<input type="number" value="500" step="0" min="0" max="10000" id="{uniqueID}_throttle">
 
-		<br>
+		<div class="spacer"></div>
 
 		<p>Sending images through rosbridge may cause TCP congestion. Lower the socket throttle rate to get faster data updates, but note that other visualizers may stutter.</p>
 
-		<hr>
+		<hr class="dark_hr"/>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/folder/folder_modal.html
+++ b/public/templates/folder/folder_modal.html
@@ -9,7 +9,7 @@
 			</div>
 		</div>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_remove" class="delete_button">Remove Folder</button>
 

--- a/public/templates/grid/grid_modal.html
+++ b/public/templates/grid/grid_modal.html
@@ -2,9 +2,9 @@
 	<div class="modal_inner noselect">
 		<h3>Grid Renderer</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_autoscale">Autoscale</label>
 		<!-- <input type="checkbox" checked id="{uniqueID}_autoscale"> -->
@@ -27,17 +27,17 @@
 		<label for="{uniqueID}_step">Step (meter):</label>
 		<input type="number" value="1.0" step="0.01" min="0.01" max="10000" id="{uniqueID}_step">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_thickness">Line thickness (px):</label>
 		<input type="number" value="1" step="1" min="1" max="20" id="{uniqueID}_thickness">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_colorpicker">Color:</label>
 		<input type="color" value="#3e556a" id="{uniqueID}_colorpicker">
 
-		<br>
+		<div class="spacer"></div>
 
 		<hr class="dark_hr"/>
 
@@ -48,14 +48,14 @@
 		<label for="{uniqueID}_subdivisions">Number of subcells per cell:</label>
 		<input type="number" value="2" step="1" min="1" max="20" id="{uniqueID}_subdivisions">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_colorpicker">Color:</label>
 		<input type="color" value="#3e556a" id="{uniqueID}_colorpicker_sub">
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/gridcells/gridcells_modal.html
+++ b/public/templates/gridcells/gridcells_modal.html
@@ -2,7 +2,7 @@
 	<div class="modal_inner noselect">
 		<h3>Grid Cells</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
@@ -11,34 +11,32 @@
 
 		<p>Display a nav_msgs/GridCells message that typically represents sparse navigational obstacles.</p>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_opacity">Opacity:</label>
 		<span id="{uniqueID}_opacity_value">1.0</span>
 		<input type="range" value="1.0" step="0.05" min="0.1" max="1.0" id="{uniqueID}_opacity">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_colorpicker">Colour:</label>
 		<input type="color" value="#74ce6c" id="{uniqueID}_colorpicker">
 
-		<br>
+		<div class="spacer"></div>
+
+		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
+		<input type="number" value="500" step="0" min="0" max="10000" id="{uniqueID}_throttle">
+
+		<div class="spacer"></div>
 
 		<label>Use Timestamp:</label>
 		<input type="checkbox" id="{uniqueID}_use_timestamp">	
 
 		<p class="comment">Rendering fixed objects at their published timestamp causes them to lag behind when focusing on frames other than the map frame. Rviz uses the latest timestamp instead, which this emulates. Enable for techincally correct rendering.</p>
 
-		<br>
+		<hr class="dark_hr"/>
 
-		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
-		<input type="number" value="500" step="0" min="0" max="10000" id="{uniqueID}_throttle">
-
-		<br>
-
-		<hr>
-
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/gridcells/gridcells_script.js
+++ b/public/templates/gridcells/gridcells_script.js
@@ -61,7 +61,7 @@ if(settings.hasOwnProperty("{uniqueID}")){
 	timestampCheckbox.checked = loaded_data.use_timestamp ?? false;
 
 	colourpicker.value = loaded_data.color;
-	throttle.value = loaded_data.throttle;
+	throttle.value = loaded_data.throttle ?? 100;
 }else{
 	saveSettings();
 }

--- a/public/templates/initialpose/initialpose_modal.html
+++ b/public/templates/initialpose/initialpose_modal.html
@@ -2,7 +2,7 @@
 	<div class="modal_inner noselect">
 		<h3>2D Pose Estimate</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
@@ -13,9 +13,9 @@
 
 		<p style="color:#b4b4b4;">Click the icon once to enable, drag on the view area and release to publish. Long press the icon to open this menu.</p>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/inspector/inspector_modal.html
+++ b/public/templates/inspector/inspector_modal.html
@@ -3,14 +3,14 @@
 		<h3>Topic Inspector</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here -->
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
 		<input type="number" value="500" step="0" min="0" max="10000" id="{uniqueID}_throttle">
@@ -31,9 +31,9 @@
 			<!-- add params here -->
 		</div>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/map/map_modal.html
+++ b/public/templates/map/map_modal.html
@@ -2,7 +2,7 @@
 	<div class="modal_inner noselect">
 		<h3>Map</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
@@ -10,7 +10,7 @@
 		</select>
 
 		<p>Display a nav_msgs/OccupancyGrid message that typically represents a 2D map or navigational costmap.</p>
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_colour_scheme">Colour scheme:</label>
 		<select id="{uniqueID}_colour_scheme">
@@ -20,62 +20,62 @@
 		  <option value="raw_transparent">Raw Transparent</option>
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_opacity">Opacity:</label>
 		<span id="{uniqueID}_opacity_value">0.7</span>
 		<input type="range" value="0.7" step="0.05" min="0.0" max="1.0" id="{uniqueID}_opacity">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
 		<input type="number" value="1000" step="0" min="0" max="10000" id="{uniqueID}_throttle">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label>Use Timestamp:</label>
 		<input type="checkbox" id="{uniqueID}_use_timestamp">	
 
 		<p class="comment">Rendering maps at their published timestamp causes them to lag behind when focusing on frames other than the map frame. Rviz uses the latest timestamp instead, which this emulates. Enable for techincally correct rendering.</p>
 
-		<br>
+		<div class="spacer"></div>
 
 		<h4>Management</h4>
 
 		<p class="comment">Relay services for calling map loading and saving nodes.</p>
 
 		<i>💾 map_saver</i>
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_savepath">Save to path:</label>
 		<input id="{uniqueID}_savepath" type="text" value="~/.ros/map">
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_save">Save</button>
 
-		<br>
+		<div class="spacer"></div>
 
 		<i>🖶 map_server</i>
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_loadpath">Load from path:</label>
 		<input id="{uniqueID}_loadpath" type="text" value="~/.ros/map">
 
-		<br>
+		<div class="spacer"></div>
 
 
 		<label for="{uniqueID}_loadtopic">Publish on topic:</label>
 		<input id="{uniqueID}_loadtopic" type="text" value="/map">
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_load">Load</button>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/markerarray/markerarray_modal.html
+++ b/public/templates/markerarray/markerarray_modal.html
@@ -2,7 +2,7 @@
 	<div class="modal_inner noselect">
 		<h3>Marker Array</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
@@ -11,7 +11,13 @@
 
 		<p>Render primitive shapes to the 2D view. Note that not all marker types are currently supported (yet!).</p>
 
-		<hr>
+		<div class="spacer"></div>
+
+		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
+		<input type="number" value="100" step="1" min="0" max="10000" id="{uniqueID}_throttle">
+
+
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/markerarray/markerarray_script.js
+++ b/public/templates/markerarray/markerarray_script.js
@@ -27,17 +27,25 @@ const icon = document.getElementById("{uniqueID}_icon").getElementsByTagName('im
 const canvas = document.getElementById('{uniqueID}_canvas');
 const ctx = canvas.getContext('2d', { colorSpace: 'srgb' });
 
+const throttle = document.getElementById('{uniqueID}_throttle');
+throttle.addEventListener("input", (event) =>{
+	saveSettings();
+	connect();
+});
+
 //Settings
 if(settings.hasOwnProperty("{uniqueID}")){
 	const loaded_data  = settings["{uniqueID}"];
 	topic = loaded_data.topic;
+	throttle.value = loaded_data.throttle ?? 100;
 }else{
 	saveSettings();
 }
 
 function saveSettings(){
 	settings["{uniqueID}"] = {
-		topic: topic
+		topic: topic,
+		throttle: throttle.value
 	}
 	settings.save();
 }
@@ -223,7 +231,8 @@ function connect(){
 		ros : rosbridge.ros,
 		name : topic,
 		messageType : 'visualization_msgs/MarkerArray',
-		compression: "cbor"
+		compression: "cbor",
+		throttle_rate: parseInt(throttle.value)
 	});
 
 	status.setWarn("No data received.");

--- a/public/templates/nodemgr/nodemgr_modal.html
+++ b/public/templates/nodemgr/nodemgr_modal.html
@@ -1,11 +1,11 @@
 <div id="{uniqueID}_modal" class="modal_outer noselect">
 	<div class="modal_inner noselect">
 		<h3>Node Manager</h3>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<b>Launch Node:</b>
 
-		<br>
+		<div class="spacer"></div>
 
 		<select id="{uniqueID}_type">
 			<option value="rosrun">rosrun</option>
@@ -25,32 +25,32 @@
 
 		<p style="color: lightgray">Note: Package executable detection is experimental so not all or too many files might show up.</p>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_execute">Execute</button>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 		<b>Diagnostics:</b>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_roswtf">roswtf</button>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<b>Running Nodes:</b>
-		<br>
+		<div class="spacer"></div>
 		<div id="{uniqueID}_nodelist">
 			
 		</div>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 
@@ -60,13 +60,13 @@
 <div id="{uniqueID}_contextmodal" class="modal_outer noselect">
 	<div class="modal_inner noselect">
 		<h3 id="{uniqueID}_context_title"></h3>
-		<hr>
+		<hr class="dark_hr"/>
 
-		<br>
+		<div class="spacer"></div>
 
 		<p id="{uniqueID}_rosnode_info" style="color:lightgray">Waiting for rosnode info...</p>
 		
-		<hr>
+		<hr class="dark_hr"/>
 
 		<p>Note that if a node is set to respawn, it'll automatically restart itself.</p>
 
@@ -78,9 +78,9 @@
 <div id="{uniqueID}_roswtfmodal" class="modal_outer noselect">
 	<div class="modal_inner noselect">
 		<h3>Roswtf Diagnostics</h3>
-		<hr>
+		<hr class="dark_hr"/>
 
-		<br>
+		<div class="spacer"></div>
 
 		<p id="{uniqueID}_roswtf_data" style="color:lightgray">Waiting for roswtf report...</p>
 		

--- a/public/templates/odom/odom_modal.html
+++ b/public/templates/odom/odom_modal.html
@@ -2,51 +2,47 @@
 	<div class="modal_inner noselect">
 		<h3>Pose Tracker</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Target:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
 		</select>
 
-		<br>
+		<p>Track a TF link or nav_msgs/Odometry data.</p>
+
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_colorpicker">Colour:</label>
 		<input type="color" value="#c43b00" id="{uniqueID}_colorpicker">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_history">History (N):</label>
 		<input type="number" value="200" step="1" min="2" max="10000" id="{uniqueID}_history">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_throttle">Sample delay (ms):</label>
 		<input type="number" value="500" step="1" min="0" max="10000" id="{uniqueID}_throttle">
 
-		<br>
-		<hr>
-		<br>
+		<div class="spacer"></div>
 
 		<label>Draw path:</label>
 		<input type="checkbox" checked id="{uniqueID}_draw_path">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label>Draw arrows:</label>
 		<input type="checkbox" checked id="{uniqueID}_draw_arrows">
 
-		<br>
-
-		<p>Track a TF link or nav_msgs/Odometry data.</p>
-
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_clearhistory" style="background-color: rgb(104, 78, 31);">Clear history</button>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/path/path_modal.html
+++ b/public/templates/path/path_modal.html
@@ -2,28 +2,28 @@
 	<div class="modal_inner noselect">
 		<h3>Path</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_colorpicker">Colour:</label>
 		<input type="color" value="#54db67" id="{uniqueID}_colorpicker">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
 		<input type="number" value="100" step="1" min="0" max="10000" id="{uniqueID}_throttle">
 
-		<br>
+		<div class="spacer"></div>
 
 		<p>Display a nav_msgs/Path.</p>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/pointcloud/pointcloud_modal.html
+++ b/public/templates/pointcloud/pointcloud_modal.html
@@ -2,45 +2,45 @@
 	<div class="modal_inner noselect">
 		<h3>Point Cloud</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_opacity">Opacity:</label>
 		<span id="{uniqueID}_opacity_value">1.0</span>
 		<input type="range" value="1.0" step="0.05" min="0.1" max="1.0" id="{uniqueID}_opacity">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_thickness">Thickness (m):</label>
 		<span id="{uniqueID}_thickness_value">0.02</span>
 		<input type="range" value="0.02" step="0.01" min="0.01" max="0.2" id="{uniqueID}_thickness">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_colorpicker">Colour:</label>
 		<input type="color" value="#1f8eec" id="{uniqueID}_colorpicker">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
 		<input type="number" value="2000" step="0" min="0" max="10000" id="{uniqueID}_throttle">
 
-		<br>
+		<div class="spacer"></div>
 
 		<p>Point clouds are very high bandwidth topics, and as such can easily cause TCP congestion. Lower the socket throttle rate to get faster data updates, but note that other visualizers may stutter.</p>
 
 		<p style="color:#b4b4b4;">Currently experimental and might not decode all cloud formats correctly. XYZ coordinate data is required, the rest is ignored for now.</p>
 
 
-		<hr>
+		<hr class="dark_hr"/>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/posearray/posearray_modal.html
+++ b/public/templates/posearray/posearray_modal.html
@@ -2,29 +2,34 @@
 	<div class="modal_inner noselect">
 		<h3>Pose Array</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
 		</select>
 
-		<br>
+		<p>Display an array of Poses as a cloud of arrows.</p>
+
+		<hr class="dark_hr"/>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_colorpicker">Colour:</label>
 		<input type="color" value="#f74127" id="{uniqueID}_colorpicker">
 
-		<br>
+		<div class="spacer"></div>
 
-		<p>Display an array of Poses as a cloud of arrows.</p>
+		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
+		<input type="number" value="100" step="1" min="0" max="10000" id="{uniqueID}_throttle">
 
-		<br>
+		<div class="spacer"></div>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_scale">Arrow scale:</label>
 		<span id="{uniqueID}_scale_value">1.0</span>
 		<input type="range" value="1.0" step="0.01" min="0.1" max="10.0" id="{uniqueID}_scale">
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/posearray/posearray_script.js
+++ b/public/templates/posearray/posearray_script.js
@@ -40,6 +40,12 @@ colourpicker.addEventListener("input", (event) =>{
 	drawArrows();
 });
 
+const throttle = document.getElementById('{uniqueID}_throttle');
+throttle.addEventListener("input", (event) =>{
+	saveSettings();
+	connect();
+});
+
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const click_icon = document.getElementById("{uniqueID}_icon");
 const icon = click_icon.getElementsByTagName('object')[0];
@@ -56,7 +62,7 @@ if(settings.hasOwnProperty("{uniqueID}")){
 
 	scaleSlider.value = loaded_data.scale;
 	scaleSliderValue.textContent = scaleSlider.value;
-
+	throttle.value = loaded_data.throttle ?? 100;
 }else{
 	saveSettings();
 }
@@ -73,7 +79,8 @@ function saveSettings(){
 	settings["{uniqueID}"] = {
 		topic: topic,
 		scale: parseFloat(scaleSlider.value),
-		color: colourpicker.value
+		color: colourpicker.value,
+		throttle: throttle.value
 	}
 	settings.save();
 }
@@ -166,7 +173,7 @@ function connect(){
 		ros : rosbridge.ros,
 		name : topic,
 		messageType : 'geometry_msgs/PoseArray',
-		throttle_rate: 50,
+		throttle_rate: parseInt(throttle.value),
 		compression: "cbor"
 	});
 

--- a/public/templates/posewithcovariancestamped/posewithcovariancestamped_modal.html
+++ b/public/templates/posewithcovariancestamped/posewithcovariancestamped_modal.html
@@ -2,39 +2,60 @@
 	<div class="modal_inner noselect">
 		<h3>Pose</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
 		</select>
 
-		<br>
+		<div class="live_data_display">
+			<p id="{uniqueID}_live_x">X: ?</p>
+			<p id="{uniqueID}_live_y">Y: ?</p> 
+			<p id="{uniqueID}_live_z">Z: ?</p>
+			<p id="{uniqueID}_live_dist">Distance: ?</p>
+			<p id="{uniqueID}_live_roll">Roll: ?</p>
+			<p id="{uniqueID}_live_pitch">Pitch: ?</p>
+			<p id="{uniqueID}_live_yaw">Yaw: ?</p>
+		</div>
 
-		<label for="{uniqueID}_colorpicker">Colour:</label>
-		<input type="color" value="#f74127" id="{uniqueID}_colorpicker">
+		<p>Render a single PoseStamped or PoseWithCovarianceStamped.</p>
 
-		<br>
+		<p class="comment">Note: Covariance rendering assumes a 2D pose for simplicity. Side effects may include inaccuracy in high roll/pitch orientations, ask your PhD if 2D covariance rendering is right for you.</p>
 
-		<p>Render a single Pose or PoseWithCovariance.</p>
-			
+		<hr class="dark_hr"/>
 
-		<br>
+		<div class="spacer"></div>
 
-		<label for="{uniqueID}_scale">Arrow scale:</label>
-		<span id="{uniqueID}_scale_value">1.0</span>
-		<input type="range" value="1.0" step="0.01" min="0.1" max="10.0" id="{uniqueID}_scale">
+		<label for="{uniqueID}_rendermode">Render mode:</label>
+		<select id="{uniqueID}_rendermode" name="topic">
+			<option value='long_arrow'>Long Arrow</option>
+			<option value='axes'>Axes</option>
+		</select>
 
-		<br>
+		<div class="spacer"></div>
+
+		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
+		<input type="number" value="100" step="1" min="0" max="10000" id="{uniqueID}_throttle">
+
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_decay">Decay time (ms):</label>
 		<input type="number" value="10000" step="0" min="-1" max="100000" id="{uniqueID}_decay">
 
+		<div class="spacer"></div>
 
-		<p class="comment">Note: Covariance rendering assumes a 2D pose for simplicity. Side effects may include inaccuracy in high roll/pitch orientations, ask your PhD if 2D covariance rendering is right for you.</p>
+		<label for="{uniqueID}_colorpicker">Colour:</label>
+		<input type="color" value="#f74127" id="{uniqueID}_colorpicker">
 
+		<div class="spacer"></div>
+		<div class="spacer"></div>
 
-		<hr>
+		<label for="{uniqueID}_scale">Render scale:</label>
+		<span id="{uniqueID}_scale_value">1.0</span>
+		<input type="range" value="1.0" step="0.01" min="0.01" max="15.0" id="{uniqueID}_scale">
+
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/posewithcovariancestamped/posewithcovariancestamped_script.js
+++ b/public/templates/posewithcovariancestamped/posewithcovariancestamped_script.js
@@ -7,6 +7,7 @@ let utilModule = await import(`${base_url}/js/modules/util.js`);
 
 let view = viewModule.view;
 let tf = tfModule.tf;
+let applyRotation = tfModule.applyRotation;
 let rosbridge = rosbridgeModule.rosbridge;
 let settings = persistentModule.settings;
 let Status = StatusModule.Status;
@@ -28,6 +29,15 @@ let marker_topic = undefined;
 let posemsg = undefined;
 let frame = "";
 
+const text_x = document.getElementById("{uniqueID}_live_x");
+const text_y = document.getElementById("{uniqueID}_live_y");
+const text_z = document.getElementById("{uniqueID}_live_z");
+const text_dist = document.getElementById("{uniqueID}_live_dist");
+const text_roll = document.getElementById("{uniqueID}_live_roll");
+const text_pitch = document.getElementById("{uniqueID}_live_pitch");
+const text_yaw = document.getElementById("{uniqueID}_live_yaw");
+
+const rendermodebox = document.getElementById("{uniqueID}_rendermode");
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const click_icon = document.getElementById("{uniqueID}_icon");
 const icon = click_icon.getElementsByTagName('object')[0];
@@ -54,6 +64,12 @@ decay.addEventListener("input", (event) =>{
 	connect();
 });
 
+const throttle = document.getElementById('{uniqueID}_throttle');
+throttle.addEventListener("input", (event) =>{
+	saveSettings();
+	connect();
+});
+
 const canvas = document.getElementById('{uniqueID}_canvas');
 const ctx = canvas.getContext('2d', { colorSpace: 'srgb' });
 
@@ -70,6 +86,9 @@ if(settings.hasOwnProperty("{uniqueID}")){
 	typedict = loaded_data.typedict ?? {};
 
 	decay.value = loaded_data.decay ?? 10000;
+	throttle.value = loaded_data.throttle ?? 100;
+
+	rendermodebox.value = loaded_data.rendermode ?? "long_arrow";
 
 }else{
 	saveSettings();
@@ -90,12 +109,71 @@ function saveSettings(){
 		scale: parseFloat(scaleSlider.value),
 		typedict: typedict,
 		color: colourpicker.value,
-		decay: decay.value
+		decay: decay.value,
+		throttle: throttle.value,
+		rendermode: rendermodebox.value
 	}
 	settings.save();
 }
 
 async function drawMarkers(){
+
+	function drawAxes(size) {
+
+		const length = parseFloat(scaleSlider.value);
+
+		function getBasisPoints(basis, translation, rotation){
+			let basis_x = applyRotation(basis, rotation);
+			return [
+				view.fixedToScreen({
+					x: translation.x,
+					y: translation.y,
+				}), 
+				view.fixedToScreen({
+					x: translation.x + basis_x.x,
+					y: translation.y + basis_x.y,
+				})
+			];
+		}
+	
+		ctx.lineCap = 'round';
+		ctx.lineWidth = size*0.1;
+		ctx.strokeStyle = "#bf0009"; //red
+		ctx.beginPath();
+		let p = getBasisPoints(
+			{x: length, y: 0, z: 0},
+			posemsg.vec,
+			posemsg.quat
+		);
+		ctx.moveTo(parseInt(p[0].x), parseInt(p[0].y));
+		ctx.lineTo(parseInt(p[1].x), parseInt(p[1].y));
+		ctx.stroke();
+	
+		ctx.strokeStyle = "#21cc1f"; //green
+		ctx.beginPath();
+	
+		p = getBasisPoints(
+			{x: 0, y: length, z: 0},
+			posemsg.vec,
+			posemsg.quat
+		);
+		ctx.moveTo(parseInt(p[0].x), parseInt(p[0].y));
+		ctx.lineTo(parseInt(p[1].x), parseInt(p[1].y));
+		ctx.stroke();
+	
+		ctx.strokeStyle = "#0249c4"; //blue
+		ctx.beginPath();
+
+		p = getBasisPoints(
+			{x: 0, y: 0, z: length},
+			posemsg.vec,
+			posemsg.quat
+		);
+		ctx.moveTo(parseInt(p[0].x), parseInt(p[0].y));
+		ctx.lineTo(parseInt(p[1].x), parseInt(p[1].y));
+		ctx.stroke();
+	
+	}
 
 	function drawCircle(size){
 		ctx.fillStyle = colourpicker.value;
@@ -186,14 +264,19 @@ async function drawMarkers(){
 		ctx.setTransform(1,0,0,-1,screenpos.x, screenpos.y); //sx,0,0,sy,px,py
 		
 		drawTranslationalCovariance(posemsg.eigenvalues, unit);
-		ctx.setTransform(1,0,0,-1,screenpos.x, screenpos.y);
-
-		if(!posemsg.rotation_invalid)
-			ctx.rotate(posemsg.yaw);
+		ctx.setTransform(1,0,0,-1,screenpos.x, screenpos.y);			
 
 		if(!posemsg.rotation_invalid){
+			ctx.rotate(posemsg.yaw);
 			drawAngularCovariance(posemsg.covariance, scale);
-			drawArrow(scale);
+
+			if(rendermodebox.value == "long_arrow"){
+				drawArrow(scale);
+			}else{
+				ctx.setTransform(1,0,0,1,0, 0);
+				drawAxes(scale);
+			}
+				
 		}else{
 			drawCircle(scale*0.4);
 		}
@@ -254,7 +337,8 @@ function connect(){
 	marker_topic = new ROSLIB.Topic({
 		ros : rosbridge.ros,
 		name : topic,
-		messageType : typedict[topic]
+		messageType : typedict[topic],
+		throttle_rate: parseInt(throttle.value)
 	});
 
 	status.setWarn("No data received.");
@@ -299,12 +383,23 @@ function connect(){
 		posemsg = {
 			x: transformed.translation.x,
 			y: transformed.translation.y,
+			vec: transformed.translation,
+			quat: transformed.rotation,
 			yaw: transformed.rotation.toEuler().h,
 			rotation_invalid: rotation_invalid,
 			covariance: skip_covariance ? undefined : msg.pose.covariance,
 			eigenvalues: skip_covariance ? undefined : calculateEigen(msg.pose.covariance),
 			stamp: new Date()
 		};
+
+		let angles = (new Quaternion(q)).toEuler()
+		text_x.innerText = "X: "+pose.position.x.toFixed(2)+" m";
+		text_y.innerText = "Y: "+pose.position.y.toFixed(2)+" m";
+		text_z.innerText = "Z: "+pose.position.z.toFixed(2)+" m";
+		text_dist.innerText = "Distance: "+Math.hypot(pose.position.x, pose.position.y, pose.position.z).toFixed(2)+" m";
+		text_roll.innerText = "Roll: "+(angles.g * (180/Math.PI)).toFixed(1)+"°";
+		text_pitch.innerText = "Pitch: "+(angles.pitch * (180/Math.PI)).toFixed(1)+"°";
+		text_yaw.innerText = "Yaw: "+(angles.h * (180/Math.PI)).toFixed(1)+"°";
 	
 		drawMarkers();
 		
@@ -346,6 +441,14 @@ async function loadTopics(){
 }
 
 selectionbox.addEventListener("change", (event) => {
+	text_x.innerText = "X: ?";
+	text_y.innerText = "Y: ?";
+	text_z.innerText = "Z: ?";
+	text_dist.innerText = "Distance: ?";
+	text_roll.innerText = "Roll: ?";
+	text_pitch.innerText = "Pitch: ?";
+	text_yaw.innerText = "Yaw: ?";
+
 	topic = selectionbox.value;
 	posemsg = undefined;
 	connect();
@@ -357,6 +460,10 @@ selectionbox.addEventListener("click", (event) => {
 
 click_icon.addEventListener("click", (event) => {
 	loadTopics();
+});
+
+rendermodebox.addEventListener("change", (event) => {
+	saveSettings();
 });
 
 loadTopics();

--- a/public/templates/range/range_modal.html
+++ b/public/templates/range/range_modal.html
@@ -2,13 +2,12 @@
 	<div class="modal_inner noselect">
 		<h3>Range</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
 		</select>
-
 
 		<div class="live_data_display">
 			<p id="{uniqueID}_rangetext">Range: ?</p>
@@ -20,24 +19,27 @@
 
 		<p>Render a range measurement, typically from sonar or infrared sensors.</p>
 
-		<br>
+		<div class="spacer"></div>
 
-		<br>
-
+		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
+		<input type="number" value="100" step="1" min="0" max="10000" id="{uniqueID}_throttle">
+			
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_decay">Decay time (ms):</label>
 		<input type="number" value="2000" step="0" min="-1" max="60000" id="{uniqueID}_decay">
 
-		<br>
+		<div class="spacer"></div>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_opacity">Opacity:</label>
 		<span id="{uniqueID}_opacity_value">0.9</span>
 		<input type="range" value="0.9" step="0.05" min="0.1" max="1.0" id="{uniqueID}_opacity">
 
+		<div class="spacer"></div>
 
-		<br>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/range/range_script.js
+++ b/public/templates/range/range_script.js
@@ -44,6 +44,12 @@ decay.addEventListener("input", (event) =>{
 	connect();
 });
 
+const throttle = document.getElementById('{uniqueID}_throttle');
+throttle.addEventListener("input", (event) =>{
+	saveSettings();
+	connect();
+});
+
 if(settings.hasOwnProperty("{uniqueID}")){
 	const loaded_data  = settings["{uniqueID}"];
 	topic = loaded_data.topic;
@@ -52,6 +58,7 @@ if(settings.hasOwnProperty("{uniqueID}")){
 	opacityValue.innerText = loaded_data.opacity;
 
 	decay.value = loaded_data.decay ?? 2000;
+	throttle.value = loaded_data.throttle ?? 100;
 }else{
 	saveSettings();
 }
@@ -60,7 +67,8 @@ function saveSettings(){
 	settings["{uniqueID}"] = {
 		topic: topic,
 		opacity: opacitySlider.value,
-		decay: decay.value
+		decay: decay.value,
+		throttle: throttle.value
 	}
 	settings.save();
 }
@@ -191,16 +199,11 @@ function connect(){
 	range_topic = new ROSLIB.Topic({
 		ros : rosbridge.ros,
 		name : topic,
-		messageType : 'sensor_msgs/Range'
+		messageType : 'sensor_msgs/Range',
+		throttle_rate: parseInt(throttle.value)
 	});
 
-	status.setWarn("No data received.");
-	text_range.innerText = "Range: ?";
-	text_min.innerText = "Min: ?";
-	text_max.innerText = "Max: ?";
-	text_fov.innerText = "Field of view: ?";
-	text_type.innerText = "Type: ?";
-	
+	status.setWarn("No data received.");	
 	listener = range_topic.subscribe((msg) => {
 
 		let error = false;
@@ -284,6 +287,12 @@ async function loadTopics(){
 }
 
 selectionbox.addEventListener("change", (event) => {
+	text_range.innerText = "Range: ?";
+	text_min.innerText = "Min: ?";
+	text_max.innerText = "Max: ?";
+	text_fov.innerText = "Field of view: ?";
+	text_type.innerText = "Type: ?";
+
 	topic = selectionbox.value;
 	connect();
 });

--- a/public/templates/reconfigure/reconfigure_modal.html
+++ b/public/templates/reconfigure/reconfigure_modal.html
@@ -1,7 +1,7 @@
 <div id="{uniqueID}_modal" class="modal_outer noselect">
 	<div class="modal_inner noselect">
 		<h3>Dynamic Reconfigure</h3>
-		<hr>
+		<hr class="dark_hr"/>
 		<label for="{uniqueID}_node">Node name:</label>
 		<select id="{uniqueID}_node" name="node">
 			<!-- add topics here-->
@@ -9,7 +9,7 @@
 
 		<span style="display:flex; align-items: center;"><button id="{uniqueID}_refresh" style="margin-top: 12px; margin-bottom: 6px;">Refresh</button><div id="{uniqueID}_loader" class="loader"></div></span>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<div id="{uniqueID}_params">
 			<!-- add params here-->
@@ -18,7 +18,7 @@
 
 		
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/reconfigure/reconfigure_script.js
+++ b/public/templates/reconfigure/reconfigure_script.js
@@ -91,25 +91,25 @@ function createParameterInput(fullname, defaultValue, type) {
 			inputElement = `
 				<label for="${id}"><i>string </i> ${name}:</label>
 				<input id="${id}" type="text" value="${defaultValue}"><span id="${arrowId}" class="arrow" style="visibility: hidden;">➡</span>
-				<br>`;
+				<div class="spacer"></div>`;
 			break;
 		case "int":
 			inputElement = `
 				<label for="${id}"><i>int </i> ${name}:</label>
 				<input type="number" value="${defaultValue}" step="1" id="${id}"><span id="${arrowId}" class="arrow" style="visibility: hidden;">➡</span>
-				<br>`;
+				<div class="spacer"></div>`;
 			break;
 		case "float":
 			inputElement = `
 				<label for="${id}"><i>float </i>${name}:</label>
 				<input type="number" value="${defaultValue}" step="0.001" id="${id}"><span id="${arrowId}" class="arrow" style="visibility: hidden;">➡</span>
-				<br>`;
+				<div class="spacer"></div>`;
 			break;
 		case "bool":
 			inputElement = `
 				<label for="${id}"><i>bool </i>${name}:</label>
 				<input type="checkbox" id="${id}" ${defaultValue ? "checked" : ""}><span id="${arrowId}" class="arrow" style="visibility: hidden;">➡</span>
-				<br>`;
+				<div class="spacer"></div>`;
 			break;
 		default:
 			console.error("Invalid parameter type:", type);

--- a/public/templates/robotmodel/robotmodel_modal.html
+++ b/public/templates/robotmodel/robotmodel_modal.html
@@ -2,36 +2,36 @@
 	<div class="modal_inner noselect">
 		<h3>Robot Model</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_frame">Frame:</label>
 		<select id="{uniqueID}_frame" name="topic">
 			<option value='base_link'>base_link</option>
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_sprite">Robot Sprite:</label>
 		<select id="{uniqueID}_sprite" name="topic">
 			<option value='4wd'>4wd</option>
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<img src="assets/robot_model/_4wd.png" alt="modelimg" width="80%" id="{uniqueID}_previewimg">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_length">Robot Length (m):</label>
 		<input type="number" value="0.5" step="0.01" min="0.01" max="100" id="{uniqueID}_length">
 
-		<br>
+		<div class="spacer"></div>
 
 		
-		<p>Add your custom sprite into </p><input type="text" value="vizanti/public/assets/robot_model/" readonly><br><br>
+		<p>Add your custom sprite into </p><input type="text" value="vizanti/public/assets/robot_model/" readonly><div class="spacer"></div><div class="spacer"></div>
 		<p>The files should start with an underscore, must be in .png format and will rotate around the image center.</p>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/rosbag/rosbag_modal.html
+++ b/public/templates/rosbag/rosbag_modal.html
@@ -1,36 +1,36 @@
 <div id="{uniqueID}_modal" class="modal_outer noselect">
 	<div class="modal_inner noselect">
 		<h3>Bag Recorder</h3>
-		<hr>
+		<hr class="dark_hr"/>
 
 
 		<label for="{uniqueID}_savepath">Save to path:</label>
 		<input id="{uniqueID}_savepath" type="text" value="~/recording.bag">
 
-		<br>
+		<div class="spacer"></div>
 
 
 		<button id="{uniqueID}_selectall">Select All</button>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_selectnone">Select None</button>
 		
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_toggle" style="background-color: rgb(38, 104, 31);">Start recording</button>
 
-		<br>
+		<div class="spacer"></div>
 
 		<b>Topics:</b>
-		<br>
+		<div class="spacer"></div>
 		<div id="{uniqueID}_topics">
 			
 		</div>
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/rosbag/rosbag_script.js
+++ b/public/templates/rosbag/rosbag_script.js
@@ -14,7 +14,7 @@ const icon = document.getElementById("{uniqueID}_icon").getElementsByTagName('im
 
 let path = "~/recording.bag";
 let topic_list = new Set();
-let active = await getRecordingStatus();
+let active = false;
 
 if(settings.hasOwnProperty("{uniqueID}")){
 	const loaded_data  = settings["{uniqueID}"];
@@ -44,8 +44,9 @@ async function getRecordingStatus(topics, start, path) {
 	return new Promise((resolve, reject) => {
 		const request = new ROSLIB.ServiceRequest({ topics, start, path });
 		recordRosbagService.callService(request, (result) => {
-			console.log(result.message);
-			resolve(result.success);
+			//console.log(result.message);
+			setState(result.success);
+			resolve(result.success);			
 		}, (error) => {
 			console.log(error);
 			resolve(false);
@@ -88,7 +89,6 @@ async function recordRosbag(topics, start, path) {
 }
 
 function setState(state){
-
 	if(state){
 		startButton.style.backgroundColor = "#e14044ff";
 		startButton.style.color = "black";
@@ -158,6 +158,9 @@ savePathBox.addEventListener('input', async () => {
 const topicsDiv = document.getElementById('{uniqueID}_topics');
 
 async function updateTopics(){
+	//recheck in case another client started a recording
+	await getRecordingStatus();
+
 	let result = await rosbridge.get_all_topics();
 
 	topicsDiv.innerHTML = '';
@@ -177,7 +180,8 @@ async function updateTopics(){
 
 	// Create checkboxes for each group of topics
 	topicsByType.forEach((topics, type) => {
-		const brBefore = document.createElement('br');
+		const brBefore = document.createElement('div');
+		brBefore.className = 'spacer';
 		topicsDiv.appendChild(brBefore);
 
 		const button = document.createElement('button');
@@ -211,7 +215,8 @@ async function updateTopics(){
 			span.appendChild(label);
 			div.appendChild(span);
 
-			const br = document.createElement('br');
+			const br = document.createElement('div');
+			br.className = 'spacer';
 			div.appendChild(br);
 
 			if(checkbox.checked)
@@ -220,9 +225,6 @@ async function updateTopics(){
 
 		topicsDiv.appendChild(button);
 		topicsDiv.appendChild(div);
-
-		const brAfter = document.createElement('br');
-		topicsDiv.appendChild(brAfter);
 	});
 
 	// Add event listener to all collapsible buttons
@@ -242,6 +244,5 @@ async function updateTopics(){
 
 icon.addEventListener("click", updateTopics);
 updateTopics();
-setState(active);
 
 console.log("Rosbag Widget Loaded {uniqueID}")

--- a/public/templates/rosbridge/rosbridge_modal.html
+++ b/public/templates/rosbridge/rosbridge_modal.html
@@ -1,13 +1,13 @@
 <div id="{uniqueID}_modal" class="modal_outer noselect">
 	<div class="modal_inner noselect">
 		<h3>Rosbridge Connection</h3>
-		<hr>
+		<hr class="dark_hr"/>
 		<p id="{uniqueID}_status" class="status" style="font-size: 1rem;"></p>
 		<p id="{uniqueID}_url"></p>
 
 		<p class="comment">A WS (not WSS) rosbridge instance is expected on port 5001 by default.</p>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_reload">Force reload</button>
 

--- a/public/templates/satelite/satelite_modal.html
+++ b/public/templates/satelite/satelite_modal.html
@@ -2,7 +2,7 @@
 	<div class="modal_inner noselect">
 		<h3>Satelite Tiles</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
@@ -16,52 +16,53 @@
 			<p id="{uniqueID}_covariance">Ground Covariance: ?</p>
 		</div>
 
+
 		Renders a tile map based on sensor_msgs/NavSatFix positional data. Use with a local origin for best results.
 
-		<br>
+		<div class="spacer"></div>
+		<hr class="dark_hr"/>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_tileserver">Tile server URL:</label>
 		<input style="margin-top: 0.3em; margin-bottom: 0.3em; width: 95%"id="{uniqueID}_tileserver" type="text" value="https://tile.openstreetmap.org/{z}/{x}/{y}.png">
 
 		<p class="comment">The tile server can be changed to anything that uses 265x256 sized tiles, the Web Mercator projection, and follows the same {x},{y},{z} convention. </p>
 
-		<br>
-
-		<br>
+		<div class="spacer"></div>
 
 		<label>Texture smoothing:</label>
 		<input type="checkbox" checked id="{uniqueID}_smoothing">
 
 		<p class="comment">Max tile zoom doesn't provide much detail up close, so you get to chose between pixelated or blurry.</p>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label>Ignore tf rotations:</label>
 		<input type="checkbox" checked id="{uniqueID}_ignore_rotation">
 
 		<p class="comment">Displaying the map with 0 yaw rotation can make viewing raw NavSatFix data from receivers more stable, but don't expect the robot to be facing the right way.</p>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_opacity">Opacity:</label>
 		<span id="{uniqueID}_opacity_value">0.7</span>
 		<input type="range" value="0.7" step="0.05" min="0.0" max="1.0" id="{uniqueID}_opacity">
 
-		<br>
+		<div class="spacer"></div>
 
 		<h4>Tile Management</h4>
 
 		<p>Import and export downloaded tiles to a file.</p>
 
-		<br>
+		<div class="spacer"></div>
 
 		<span><button id="{uniqueID}_export_DB" class="export_button">⇑ Export</button><button id="{uniqueID}_import_DB" class="export_button">⇓ Import</button></span>
 
-		<br>
+		<div class="spacer"></div>
 
 		<p class="comment">All fetched tiles are stored in IndexedDB for quick loading and offline use. However, browser-cached data is tied to the site's URL, so if your robot's IP changes (e.g. switching from a local network to offline AP mode), the tiles won't be accessible. To solve this, fetch and export the database while online, and reimport it in offline mode or on other machines.</p>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/satelite/satelite_script.js
+++ b/public/templates/satelite/satelite_script.js
@@ -305,7 +305,8 @@ function connect(){
 	map_topic = new ROSLIB.Topic({
 		ros : rosbridge.ros,
 		name : topic,
-		messageType : 'sensor_msgs/NavSatFix'
+		messageType : 'sensor_msgs/NavSatFix',
+		throttle_rate: 33
 	});
 
 	status.setWarn("No data received.");

--- a/public/templates/scan/scan_modal.html
+++ b/public/templates/scan/scan_modal.html
@@ -2,14 +2,12 @@
 	<div class="modal_inner noselect">
 		<h3>Laser Scan</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
 		</select>
-
-		<br>
 
 		<div class="live_data_display">
 			<p id="{uniqueID}_frame_text">TF Frame: ?</p>
@@ -24,36 +22,36 @@
 
 		Renders lidar scan points based on sensor_msgs/LaserScan data.
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_opacity">Opacity:</label>
 		<span id="{uniqueID}_opacity_value">1.0</span>
 		<input type="range" value="1.0" step="0.05" min="0.0" max="1.0" id="{uniqueID}_opacity">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_thickness">Thickness (m):</label>
 		<span id="{uniqueID}_thickness_value">0.02</span>
 		<input type="range" value="0.02" step="0.01" min="0.01" max="0.5" id="{uniqueID}_thickness">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_colorpicker">Colour:</label>
 		<input type="color" value="#ff0000" id="{uniqueID}_colorpicker">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_throttle">Socket throttle (ms):</label>
 		<input type="number" value="2000" step="1" min="0" max="10000" id="{uniqueID}_throttle">
 
-		<br>
+		<div class="spacer"></div>
 
 		<p class="comment">Laser scans are typically high bandwidth topics, and as such can easily cause TCP congestion. Lower the socket throttle rate to get faster data updates, but note that other visualizers may stutter.</p>
 
 
-		<hr>
+		<hr class="dark_hr"/>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/settings/settings_modal.html
+++ b/public/templates/settings/settings_modal.html
@@ -2,23 +2,21 @@
 	<div class="modal_inner noselect">
 		<h3>Global Settings</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_fixedframe">Fixed Frame:</label>
 		<select id="{uniqueID}_fixedframe" name="topic">
 			
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_colorpicker">Background Color:</label>
 		<input type="color" value="#273444" id="{uniqueID}_colorpicker">
 
 
-		<br>
-		<hr>
-
-		<br>
+		<div class="spacer"></div>
+		<hr class="dark_hr"/>
 
 		<h4>Manage settings</h4>
 
@@ -28,17 +26,17 @@
 			or so it can be <a href="https://github.com/MoffKalast/vizanti/wiki/Advanced-Configuration#adding-a-default-config" class="highlight-link">set as a default config</a>.
 		</p>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_reset_view">Reset Camera View</button>
 		<p class="comment">Reset only the camera to its default pose (zero relative to the fixed frame link).</p>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_delete_persistent" style="border: 3px solid #784b4b; background-color: #4d2626;" style="float: left;" >Reset Layout to default</button>
 		<p class="comment">Clear layout and import server defaults.</p>
 
-		<br>
+		<div class="spacer"></div>
 		
 	</div>
 </div>

--- a/public/templates/simplegoal/simplegoal_modal.html
+++ b/public/templates/simplegoal/simplegoal_modal.html
@@ -2,7 +2,7 @@
 	<div class="modal_inner noselect">
 		<h3>2D Nav Goal</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
@@ -14,9 +14,9 @@
 		<p style="color:#b4b4b4;">Click the icon once to enable, drag on the view area and release to publish. Long press the icon to open this menu.</p>
 
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/speedometer/speedometer_modal.html
+++ b/public/templates/speedometer/speedometer_modal.html
@@ -2,7 +2,7 @@
 	<div class="modal_inner noselect">
 		<h3>Speedometer</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_frame">Measure speed of TF link</label>
 		<select id="{uniqueID}_frame" name="topic">
@@ -14,7 +14,7 @@
 			<option value='map'>map</option>
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_units">Units:</label>
 		<select id="{uniqueID}_units" name="topic">
@@ -26,14 +26,15 @@
 			<option value='b/s'>Bananas per second (b/s)</option>
 		</select>
 
-		<hr>
+		<div class="live_data_display">
+			<p id="{uniqueID}_spd">Speed: ?</p>
+			<p id="{uniqueID}_spd_max">Max Speed: ?</p> 
+			<p id="{uniqueID}_spd_min">Min Speed: ?</p>
+		</div>
 
-		<p id="{uniqueID}_spd">Speed: ?</p>
-		<p id="{uniqueID}_spd_max">Max Speed: ?</p> 
-		<p id="{uniqueID}_spd_min">Min Speed: ?</p>
 		<button id="{uniqueID}_reset">Reset Tracking</button>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/teleop/teleop_modal.html
+++ b/public/templates/teleop/teleop_modal.html
@@ -7,7 +7,7 @@
 	<div class="modal_inner noselect">
 		<h3>Joystick Teleop</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
@@ -22,13 +22,13 @@
 		<span id="{uniqueID}_linear_velocity_value">0.5</span>
 		<input type="range" value="0.4" step="0.05" min="0.05" max="3.0" id="{uniqueID}_linear_velocity">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_angular_velocity">Angular Velocity (m/s):</label>
 		<span id="{uniqueID}_angular_velocity_value">0.5</span>
 		<input type="range" value="0.8" step="0.05" min="0.05" max="6.0" id="{uniqueID}_angular_velocity">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_accel">Linear Acceleration (m/s²):</label>
 		<span id="{uniqueID}_accel_value">0.05</span>
@@ -38,16 +38,16 @@
 		<label>Invert angular velocity when reversing:</label>
 		<input type="checkbox" checked id="{uniqueID}_invert_angular">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label>Use holonomic linear Y instead of angular Z:</label>
 		<input type="checkbox" id="{uniqueID}_holonomic">
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/temperature/temperature_modal.html
+++ b/public/templates/temperature/temperature_modal.html
@@ -2,34 +2,36 @@
 	<div class="modal_inner noselect">
 		<h3>Temperature</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<!-- add topics here-->
 		</select>
 
-		<br>
+		<div class="live_data_display">
+			<p id="{uniqueID}_temperature">Temperature (°C): ?</p>
+			<p id="{uniqueID}_variance">Variance: ?</p>
+			<p id="{uniqueID}_tflink">TF Frame: ?</p>
+		</div>
 
-		<p>Define indicator values:</p>
+		<p>Set indicator values:</p>
 
 		<img src="assets/temp_hot.svg" alt="" width="35" height="35" style="vertical-align: middle;">
 		<label for="{uniqueID}_hightemp">High (°C):</label>
 		<input type="number" value="60" step="0.1" min="-272" max="3000" id="{uniqueID}_hightemp">
 
-		<br>
+		<div class="spacer"></div>
 
 		<img src="assets/temp_cold.svg" alt="" width="35" height="35" style="vertical-align: middle;">
 		<label for="{uniqueID}_lowtemp">Low (°C):</label>
 		<input type="number" value="20" step="0.1" min="-272" max="3000" id="{uniqueID}_lowtemp">
 
-		<br>
+		<div class="spacer"></div>
 
-		<hr>
+		<p class="comment">The indicator icon will change based on the above defined threshold values.</p>
 
-		<p id="{uniqueID}_temperature">Temperature (°C): ?</p>
-		<p id="{uniqueID}_variance">Variance: ?</p>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/temperature/temperature_script.js
+++ b/public/templates/temperature/temperature_script.js
@@ -32,6 +32,7 @@ const lowBox = document.getElementById('{uniqueID}_lowtemp');
 
 const text_temperature = document.getElementById("{uniqueID}_temperature");
 const text_variance = document.getElementById("{uniqueID}_variance");
+const text_link = document.getElementById("{uniqueID}_tflink");
 
 if(settings.hasOwnProperty("{uniqueID}")){
 	const loaded_data  = settings["{uniqueID}"];
@@ -65,7 +66,8 @@ function connect(){
 	temperature_topic = new ROSLIB.Topic({
 		ros : rosbridge.ros,
 		name : topic,
-		messageType : 'sensor_msgs/Temperature'
+		messageType : 'sensor_msgs/Temperature',
+		throttle_rate: 500 // throttle to twice a second max
 	});
 
 	status.setWarn("No data received.");
@@ -84,6 +86,7 @@ function connect(){
 
 		text_temperature.innerText = "Temperature (°C): "+(Math.round(msg.temperature * 100) / 100).toFixed(2);
 		text_variance.innerText = "Variance: "+(Math.round(msg.variance * 100) / 100).toFixed(2);
+		text_link.innerText = "TF Frame: "+msg.header.frame_id;
 
 		status.setOK();
 	});

--- a/public/templates/tf/tf_modal.html
+++ b/public/templates/tf/tf_modal.html
@@ -2,43 +2,44 @@
 	<div class="modal_inner noselect">
 		<h3>TF Frame Renderer</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label>Names:</label>
 		<input type="checkbox" checked id="{uniqueID}_shownames">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label>Axes:</label>
 		<input type="checkbox" checked id="{uniqueID}_showaxes">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label>Lines:</label>
 		<input type="checkbox" checked id="{uniqueID}_showlines">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_scale">Scale:</label>
 		<span id="{uniqueID}_scale_value">1.0</span>
 		<input type="range" value="1.0" step="0.01" min="0.3" max="2.5" id="{uniqueID}_scale">
 
-		<br>
+		<div class="spacer"></div>
 
 		<b>Frames:</b>
-		<br>
+
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_enable_all" style="background-color: #2f4d26" class="enable_all_button">Enable All</button>
 		<button id="{uniqueID}_standard_only" style="background-color: #5e602c" class="standard_only_button">Standard Only</button>
 		<button id="{uniqueID}_disable_all" style="background-color: #4d2626" class="disable_all_button">Disable All</button>
 
-		<br>
+		<div class="spacer"></div>
 
 		<div id="{uniqueID}_frames">
 			
 		</div>
 
-		<hr>
+		<hr class="dark_hr"/>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 

--- a/public/templates/tf/tf_script.js
+++ b/public/templates/tf/tf_script.js
@@ -148,7 +148,6 @@ function getBasisPoints(basis, translation, rotation){
 async function drawAxes(origin, relative, absolute) {
 
 	const unit = view.getPixelsInMapUnits(30*parseFloat(scaleSlider.value));
-	const width_unit = view.getPixelsInMapUnits(2*parseFloat(scaleSlider.value));
 
 	ctx.lineWidth = 2*parseFloat(scaleSlider.value);
 	ctx.strokeStyle = "#E0000B"; //red

--- a/public/templates/waypoints/waypoints_modal.html
+++ b/public/templates/waypoints/waypoints_modal.html
@@ -2,21 +2,21 @@
 	<div class="modal_inner noselect">
 		<h3>Waypoint Mission</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
-		<hr>
+		<hr class="dark_hr"/>
 
 		<label for="{uniqueID}_topic">Topic:</label>
 		<select id="{uniqueID}_topic" name="topic">
 			<option value="/waypoints">/waypoints</option>
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_fixed_frame">Fixed Frame:</label>
 		<select id="{uniqueID}_fixed_frame" name="topic">
 			<option value="map">map</option>
 		</select>
 
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_base_link_frame">Robot Frame:</label>
 		<select id="{uniqueID}_base_link_frame" name="topic">
@@ -44,29 +44,29 @@
 		
 		<p style="color: #b4b4b4;">When editing X/Y/Z positions, click the icon again to stop editing.</p>
 		
-		<br>
+		<div class="spacer"></div>
 
 		<label for="{uniqueID}_margin">Safety margin visual indicator (meters):</label>
 		<input type="number" value="0.8" step="0.1" min="0" max="1000" id="{uniqueID}_margin">
 
-		<br>
+		<div class="spacer"></div>
 
 		<label>Start from closest waypoint:</label>
 		<input type="checkbox" id="{uniqueID}_startclosest">
 
-		<br>
+		<div class="spacer"></div>
 
 		<h4>Clear Path</h4>
 
 		<button id="{uniqueID}_delete" style="background-color: rgb(104, 78, 31);">Remove all waypoints</button>
 
-		<br>
+		<div class="spacer"></div>
 
 		<p style="color: #b4b4b4;">Tip: If you're using a nav stack that doesn't use Paths or PoseArrays, but will accept simple goals, see the demo node at rosrun vizanti waypoints_to_simple_goals.py</p>
 
-		<hr>
+		<hr class="dark_hr"/>
 
-		<br>
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_remove" class="delete_button" onclick="removeWidget('{uniqueID}')">Remove Widget</button>
 


### PR DESCRIPTION
A bunch of fixes and adjustments:

- Chrome and Firefox render <br> elements differently, so they've been replaced with a <div> that looks the same on both
- horizontal lines now all consistent and slightly darker
- added socket throttle to visualizers still missing it, since playing rosbags at a higher than realtime rate can overload them otherwise
- added rviz-like axes render mode for PoseStamped
- added the raw data display container to a few widgets