### PR TITLE
TRIANGLE_LIST, nav init fix, rosbridge humble param fix (ROS 2)

### DIFF
--- a/vizanti_demos/CMakeLists.txt
+++ b/vizanti_demos/CMakeLists.txt
@@ -37,6 +37,7 @@ install(PROGRAMS
   scripts/_test_marker_array.py
   scripts/_test_parameters.py
   scripts/_test_sphere_list.py
+  scripts/_test_triangle_list.py
   scripts/_test_tf.py
   scripts/particle_cloud_to_pose_array.py
   scripts/path_to_nav2poses.py

--- a/vizanti_demos/scripts/_test_triangle_list.py
+++ b/vizanti_demos/scripts/_test_triangle_list.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+import math
+import rclpy
+
+from rclpy.node import Node
+from builtin_interfaces.msg import Duration
+from rclpy.qos import QoSProfile, QoSDurabilityPolicy
+from visualization_msgs.msg import Marker, MarkerArray
+from geometry_msgs.msg import Point
+from std_msgs.msg import ColorRGBA
+
+def euler_to_quaternion(roll, pitch, yaw):
+    cy = math.cos(yaw * 0.5)
+    sy = math.sin(yaw * 0.5)
+    cp = math.cos(pitch * 0.5)
+    sp = math.sin(pitch * 0.5)
+    cr = math.cos(roll * 0.5)
+    sr = math.sin(roll * 0.5)
+
+    return (
+        sr * cp * cy - cr * sp * sy,  # x
+        cr * sp * cy + sr * cp * sy,  # y
+        cr * cp * sy - sr * sp * cy,  # z
+        cr * cp * cy + sr * sp * sy,  # w
+    )
+
+class TriangleListTestPublisher(Node):
+    def __init__(self):
+        super().__init__("triangle_list_test_publisher")
+
+        latch = QoSProfile(depth=1, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
+
+        self.pub = self.create_publisher(
+            MarkerArray,
+            "/test_triangle_list",
+            latch,
+        )
+
+        self.angle = 0.0
+        self.angular_speed = 0.8  # rad/s
+        self.last_time = self.get_clock().now()
+
+        self.timer = self.create_timer(1/30.0, self.timer_callback)
+
+    def timer_callback(self):
+        now_time = self.get_clock().now()
+        dt = (now_time - self.last_time).nanoseconds * 1e-9
+        self.last_time = now_time
+
+        self.angle += self.angular_speed * dt
+        #self.angle = self.angle % (2.0 * math.pi)
+
+        marker_array = MarkerArray()
+        now = self.get_clock().now().to_msg()
+
+        # ------------------------------------------------------------
+        # Test 1: Flat quad (2 triangles, single color)
+        # ------------------------------------------------------------
+        marker1 = Marker()
+        marker1.header.frame_id = "map"
+        marker1.header.stamp = now
+        marker1.ns = "triangle_list_test"
+        marker1.id = 1
+        marker1.type = Marker.TRIANGLE_LIST
+        marker1.action = Marker.ADD
+        marker1.pose.orientation.w = 1.0
+        marker1.scale.x = 1.0
+        marker1.scale.y = 1.0
+        marker1.scale.z = 1.0
+        marker1.color = ColorRGBA(r=1.0, g=0.0, b=0.0, a=1.0)
+
+        p0 = Point(x=0.0, y=0.0, z=0.0)
+        p1 = Point(x=1.0, y=0.0, z=0.0)
+        p2 = Point(x=1.0, y=1.0, z=0.0)
+        p3 = Point(x=0.0, y=1.0, z=0.0)
+
+        marker1.points.extend([p0, p1, p2])
+        marker1.points.extend([p0, p2, p3])
+
+        marker_array.markers.append(marker1)
+
+        # ------------------------------------------------------------
+        # Test 2: Per-vertex colored triangle fan
+        # ------------------------------------------------------------
+        marker2 = Marker()
+        marker2.header.frame_id = "map"
+        marker2.header.stamp = now
+        marker2.ns = "triangle_list_test"
+        marker2.id = 2
+        marker2.type = Marker.TRIANGLE_LIST
+        marker2.action = Marker.ADD
+        marker2.scale.x = 1.0
+        marker2.scale.y = 1.5
+        marker2.scale.z = 1.0
+
+        qx, qy, qz, qw = euler_to_quaternion(self.angle, self.angle, self.angle)
+        marker2.pose.orientation.x = qx
+        marker2.pose.orientation.y = qy
+        marker2.pose.orientation.z = qz
+        marker2.pose.orientation.w = qw
+        marker2.pose.position.x = -3.0
+
+        center = Point(x=0.0, y=0.0, z=1.0)
+        num_triangles = 12
+        radius = 0.8
+
+        for i in range(num_triangles):
+            a0 = i * 2.0 * math.pi / num_triangles
+            a1 = (i + 1) * 2.0 * math.pi / num_triangles
+
+            p0 = center
+            p1 = Point(
+                x=center.x + math.cos(a0) * radius,
+                y=center.y + math.sin(a0) * radius,
+                z=0.0,
+            )
+            p2 = Point(
+                x=center.x + math.cos(a1) * radius,
+                y=center.y + math.sin(a1) * radius,
+                z=0.0,
+            )
+
+            marker2.points.extend([p0, p1, p2])
+
+            # MUST match points length exactly
+            for j in range(3):
+                hue = (i + j / 3.0) / num_triangles
+                marker2.colors.append(
+                    ColorRGBA(
+                        r=abs(math.sin(hue * math.pi)),
+                        g=abs(math.sin(hue * math.pi + 2.0)),
+                        b=abs(math.sin(hue * math.pi + 4.0)),
+                        a=1.0,
+                    )
+                )
+
+        marker_array.markers.append(marker2)
+
+        # ------------------------------------------------------------
+        # Test 3: 3D pyramid (closed mesh)
+        # ------------------------------------------------------------
+        marker3 = Marker()
+        marker3.header.frame_id = "map"
+        marker3.header.stamp = now
+        marker3.ns = "triangle_list_test"
+        marker3.id = 3
+        marker3.type = Marker.TRIANGLE_LIST
+        marker3.action = Marker.ADD
+        marker3.scale.x = 1.0
+        marker3.scale.y = 1.0
+        marker3.scale.z = 1.0
+        marker3.color = ColorRGBA(r=0.0, g=1.0, b=0.0, a=0.8)
+
+        qx, qy, qz, qw = euler_to_quaternion(self.angle, 0.0, 0.0)
+        marker3.pose.orientation.x = qx
+        marker3.pose.orientation.y = qy
+        marker3.pose.orientation.z = qz
+        marker3.pose.orientation.w = qw
+
+
+        top = Point(x=4.0, y=0.0, z=1.0)
+        base = [
+            Point(x=3.5, y=-0.5, z=0.0),
+            Point(x=4.5, y=-0.5, z=0.0),
+            Point(x=4.5, y=0.5, z=0.0),
+            Point(x=3.5, y=0.5, z=0.0),
+        ]
+
+        # Base
+        marker3.points.extend([base[0], base[1], base[2]])
+        marker3.points.extend([base[0], base[2], base[3]])
+
+        # Sides
+        for i in range(4):
+            p0 = base[i]
+            p1 = base[(i + 1) % 4]
+            marker3.points.extend([p0, p1, top])
+
+        marker_array.markers.append(marker3)
+
+        # ------------------------------------------------------------
+        # Test 4: Degenerate triangle (valid but zero area)
+        # ------------------------------------------------------------
+        marker4 = Marker()
+        marker4.header.frame_id = "map"
+        marker4.header.stamp = now
+        marker4.ns = "triangle_list_test"
+        marker4.id = 4
+        marker4.type = Marker.TRIANGLE_LIST
+        marker4.action = Marker.ADD
+        marker4.pose.orientation.w = 1.0
+        marker4.scale.x = 1.0
+        marker4.scale.y = 1.0
+        marker4.scale.z = 1.0
+        marker4.color = ColorRGBA(r=1.0, g=1.0, b=0.0, a=1.0)
+
+        p = Point(x=6.0, y=0.0, z=0.0)
+        marker4.points.extend([p, p, p])
+
+        marker_array.markers.append(marker4)
+
+        self.pub.publish(marker_array)
+        self.get_logger().info(
+            f"Published {len(marker_array.markers)} triangle test markers"
+        )
+
+
+def main():
+    rclpy.init()
+    node = TriangleListTestPublisher()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/vizanti_demos/scripts/_test_triangle_list.py
+++ b/vizanti_demos/scripts/_test_triangle_list.py
@@ -59,7 +59,7 @@ class TriangleListTestPublisher(Node):
         marker1 = Marker()
         marker1.header.frame_id = "map"
         marker1.header.stamp = now
-        marker1.ns = "triangle_list_test"
+        marker1.ns = "flat_quad"
         marker1.id = 1
         marker1.type = Marker.TRIANGLE_LIST
         marker1.action = Marker.ADD
@@ -85,7 +85,7 @@ class TriangleListTestPublisher(Node):
         marker2 = Marker()
         marker2.header.frame_id = "map"
         marker2.header.stamp = now
-        marker2.ns = "triangle_list_test"
+        marker2.ns = "fan thing"
         marker2.id = 2
         marker2.type = Marker.TRIANGLE_LIST
         marker2.action = Marker.ADD
@@ -142,7 +142,7 @@ class TriangleListTestPublisher(Node):
         marker3 = Marker()
         marker3.header.frame_id = "map"
         marker3.header.stamp = now
-        marker3.ns = "triangle_list_test"
+        marker3.ns = "pyramid"
         marker3.id = 3
         marker3.type = Marker.TRIANGLE_LIST
         marker3.action = Marker.ADD
@@ -184,7 +184,7 @@ class TriangleListTestPublisher(Node):
         marker4 = Marker()
         marker4.header.frame_id = "map"
         marker4.header.stamp = now
-        marker4.ns = "triangle_list_test"
+        marker4.ns = ""
         marker4.id = 4
         marker4.type = Marker.TRIANGLE_LIST
         marker4.action = Marker.ADD

--- a/vizanti_server/launch/vizanti_server.launch.py
+++ b/vizanti_server/launch/vizanti_server.launch.py
@@ -1,5 +1,13 @@
+import os
 import launch
 import launch_ros.actions
+
+ROS_DISTRO = os.environ["ROS_DISTRO"]
+
+def distro_int_float(value):
+    if ROS_DISTRO == "jazzy":
+        return str(int(value))
+    return str(float(value))
 
 def generate_launch_description():
 
@@ -13,13 +21,13 @@ def generate_launch_description():
     #rosbridge internal params
     send_action_goals_in_new_thread = launch.substitutions.LaunchConfiguration('send_action_goals_in_new_thread', default='true')
     call_services_in_new_thread = launch.substitutions.LaunchConfiguration('call_services_in_new_thread', default='true')
-    websocket_ping_interval = launch.substitutions.LaunchConfiguration('websocket_ping_interval', default='4.0')
-    websocket_ping_timeout = launch.substitutions.LaunchConfiguration('websocket_ping_timeout', default='15.0')
     unregister_timeout = launch.substitutions.LaunchConfiguration('unregister_timeout', default='9999999.9')
     retry_startup_delay = launch.substitutions.LaunchConfiguration('retry_startup_delay', default='10.0')
     fragment_timeout = launch.substitutions.LaunchConfiguration('fragment_timeout', default='30')
     delay_between_messages = launch.substitutions.LaunchConfiguration('delay_between_messages', default='0.0')
     max_message_size = launch.substitutions.LaunchConfiguration('max_message_size', default='999999999')
+    websocket_ping_interval = launch.substitutions.LaunchConfiguration('websocket_ping_interval', default=distro_int_float(4.0))
+    websocket_ping_timeout = launch.substitutions.LaunchConfiguration('websocket_ping_timeout', default=distro_int_float(15.0))
 
     rosbridge_node = launch_ros.actions.Node(
         name='vizanti_rosbridge',

--- a/vizanti_server/launch/vizanti_server.launch.py
+++ b/vizanti_server/launch/vizanti_server.launch.py
@@ -1,13 +1,5 @@
-import os
 import launch
 import launch_ros.actions
-
-ROS_DISTRO = os.environ["ROS_DISTRO"]
-
-def distro_int_float(value):
-    if ROS_DISTRO == "jazzy":
-        return str(int(value))
-    return str(float(value))
 
 def generate_launch_description():
 
@@ -26,8 +18,8 @@ def generate_launch_description():
     fragment_timeout = launch.substitutions.LaunchConfiguration('fragment_timeout', default='30')
     delay_between_messages = launch.substitutions.LaunchConfiguration('delay_between_messages', default='0.0')
     max_message_size = launch.substitutions.LaunchConfiguration('max_message_size', default='999999999')
-    websocket_ping_interval = launch.substitutions.LaunchConfiguration('websocket_ping_interval', default=distro_int_float(4.0))
-    websocket_ping_timeout = launch.substitutions.LaunchConfiguration('websocket_ping_timeout', default=distro_int_float(15.0))
+    websocket_ping_interval = launch.substitutions.LaunchConfiguration('websocket_ping_interval', default='4.0')
+    websocket_ping_timeout = launch.substitutions.LaunchConfiguration('websocket_ping_timeout', default='15.0')
 
     rosbridge_node = launch_ros.actions.Node(
         name='vizanti_rosbridge',

--- a/vizanti_server/launch/vizanti_server.launch.py
+++ b/vizanti_server/launch/vizanti_server.launch.py
@@ -11,8 +11,10 @@ def generate_launch_description():
     default_widget_config = launch.substitutions.LaunchConfiguration('default_widget_config', default='') #e.g. ~/your_custom_config.json
 
     #rosbridge internal params
-    websocket_ping_interval = launch.substitutions.LaunchConfiguration('websocket_ping_interval', default='4')
-    websocket_ping_timeout = launch.substitutions.LaunchConfiguration('websocket_ping_timeout', default='15')
+    send_action_goals_in_new_thread = launch.substitutions.LaunchConfiguration('send_action_goals_in_new_thread', default='true')
+    call_services_in_new_thread = launch.substitutions.LaunchConfiguration('call_services_in_new_thread', default='true')
+    websocket_ping_interval = launch.substitutions.LaunchConfiguration('websocket_ping_interval', default='4.0')
+    websocket_ping_timeout = launch.substitutions.LaunchConfiguration('websocket_ping_timeout', default='15.0')
     unregister_timeout = launch.substitutions.LaunchConfiguration('unregister_timeout', default='9999999.9')
     retry_startup_delay = launch.substitutions.LaunchConfiguration('retry_startup_delay', default='10.0')
     fragment_timeout = launch.substitutions.LaunchConfiguration('fragment_timeout', default='30')
@@ -35,7 +37,9 @@ def generate_launch_description():
             {'unregister_timeout': unregister_timeout},
             {'use_compression': True},
             {'websocket_ping_interval': websocket_ping_interval},
-            {'websocket_ping_timeout': websocket_ping_timeout}
+            {'websocket_ping_timeout': websocket_ping_timeout},
+            {'send_action_goals_in_new_thread': send_action_goals_in_new_thread},
+            {'call_services_in_new_thread': call_services_in_new_thread}
         ]
     )
 

--- a/vizanti_server/public/css/style.css
+++ b/vizanti_server/public/css/style.css
@@ -447,6 +447,14 @@ object {
 }
 
 
+.param_toggle_label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 3px 5px;
+	border-radius: 3px;
+}
+
 /* Input box */
 
 input[type=color] {

--- a/vizanti_server/public/templates/map/map_script.js
+++ b/vizanti_server/public/templates/map/map_script.js
@@ -295,8 +295,20 @@ function connect(){
 		}
 
 		if(!tf.absoluteTransforms[msg.header.frame_id]){
-			status.setError("Required transform frame \""+msg.header.frame_id+"\" not found.");
-			return;
+			if(msg.header.frame_id == "map"){
+				status.setWarn("Map transform not available yet, using identity transform.");
+
+				//add a temporary transform so one can send an initialpose relative to it
+				tf.absoluteTransforms[msg.header.frame_id] = {
+					translation: {x: 0, y:0, z:0},
+					rotation: new Quaternion()
+				}
+				tf.frame_list.add("map");
+
+			}else{
+				status.setError("Required transform frame \""+msg.header.frame_id+"\" not found.");
+				return;
+			}
 		}
 
 		queueWorkerMsg(msg);

--- a/vizanti_server/public/templates/markerarray/markerarray_modal.html
+++ b/vizanti_server/public/templates/markerarray/markerarray_modal.html
@@ -9,7 +9,22 @@
 			<!-- add topics here-->
 		</select>
 
-		<p>Render primitive shapes to the 2D view. Note that not all marker types are currently supported (yet!).</p>
+		<p>Render visualization_msgs/MarkerArray batches of visualization_msgs/Marker messages.</p>
+
+		<p class="comment">Most marker types are supported, except POINTS and MESH_RESOURCE. Mileage may vary with pitch and roll rotations.</p>
+
+		<hr class="dark_hr"/>
+
+		<div class="spacer"></div>
+
+		<label>Namespaces:</label>
+		<div id="{uniqueID}_namespace" class="live_data_display"></div>
+
+		<div class="spacer"></div>
+
+		<label for="{uniqueID}_opacity">Opacity:</label>
+		<span id="{uniqueID}_opacity_value">1.0</span>
+		<input type="range" value="1.0" step="0.05" min="0.0" max="1.0" id="{uniqueID}_opacity">
 
 		<div class="spacer"></div>
 

--- a/vizanti_server/public/templates/markerarray/markerarray_script.js
+++ b/vizanti_server/public/templates/markerarray/markerarray_script.js
@@ -34,11 +34,36 @@ throttle.addEventListener("input", (event) =>{
 	connect();
 });
 
+const opacitySlider = document.getElementById('{uniqueID}_opacity');
+const opacityValue = document.getElementById('{uniqueID}_opacity_value');
+
+function setOpacityText(val){
+	if(val == 0.0)
+		opacityValue.textContent = "0.0 (Marker rendering disabled)";
+	else
+		opacityValue.textContent = val;
+}
+
+opacitySlider.addEventListener('input', () =>  {
+	setOpacityText(opacitySlider.value);
+	saveSettings();
+	drawMarkers();
+});
+
+const namespaceDiv = document.getElementById('{uniqueID}_namespace');
+let disabled_namespaces = new Set();
+
 //Settings
 if(settings.hasOwnProperty("{uniqueID}")){
 	const loaded_data  = settings["{uniqueID}"];
 	topic = loaded_data.topic;
 	throttle.value = loaded_data.throttle ?? 100;
+
+	opacitySlider.value = loaded_data.opacity ?? 1.0;
+	setOpacityText(loaded_data.opacity);
+
+	disabled_namespaces = new Set(loaded_data.disabled_namespaces) ?? new Set();
+	updateNamespaceGUI();
 }else{
 	saveSettings();
 }
@@ -47,7 +72,9 @@ if(settings.hasOwnProperty("{uniqueID}")){
 function saveSettings(){
 	settings["{uniqueID}"] = {
 		topic: topic,
-		throttle: throttle.value
+		throttle: throttle.value,
+		opacity: opacitySlider.value,
+		disabled_namespaces: [...disabled_namespaces]
 	}
 	settings.save();
 }
@@ -290,35 +317,6 @@ async function drawMarkers(){
 		}
 	}
 
-	function drawTriangleList2(marker, size) {
-		const points = marker.transformedPoints;
-		const colors = marker.colors;
-		const hasVertexColors = colors && colors.length === points.length;
-		const hasFaceColors = colors && colors.length === points.length / 3;
-		const globalAlpha = marker.color.a > 0 ? marker.color.a : 1.0;
-
-		for (let i = 0; i < points.length - 2; i += 3) {
-			const p0 = points[i], p1 = points[i + 1], p2 = points[i + 2];
-
-			if (hasVertexColors) {
-				const c = colors[i];
-				ctx.fillStyle = `rgba(${Math.round(c.r*255)}, ${Math.round(c.g*255)}, ${Math.round(c.b*255)}, ${globalAlpha * c.a})`;
-			} else if (hasFaceColors) {
-				const c = colors[i / 3];
-				ctx.fillStyle = `rgba(${Math.round(c.r*255)}, ${Math.round(c.g*255)}, ${Math.round(c.b*255)}, ${globalAlpha * c.a})`;
-			} else {
-				ctx.fillStyle = rgbaToFillColor(marker.color);
-			}
-
-			ctx.beginPath();
-			ctx.moveTo(p0.x * size, -p0.y * size);
-			ctx.lineTo(p1.x * size, -p1.y * size);
-			ctx.lineTo(p2.x * size, -p2.y * size);
-			ctx.closePath();
-			ctx.fill();
-		}
-	}
-
 	function drawTriangleList(marker, size) {
 		const tris = marker.triangles;
 		if (!tris || tris.length === 0) return;
@@ -361,10 +359,21 @@ async function drawMarkers(){
 	ctx.setTransform(1,0,0,1,0,0);
 	ctx.clearRect(0, 0, wid, hei);
 
+	ctx.globalAlpha = opacitySlider.value;
+
+	if(opacitySlider.value == 0.0){
+		return;
+	}
+
+
 	let current_time = new Date();
 
 	for (const key of z_sorted_keys) {
 		const marker = markers[key];
+		const ns = marker.ns || '';
+
+		if (disabled_namespaces.has(ns))
+			continue;
 		
 		ctx.fillStyle = rgbaToFillColor(marker.color);
 
@@ -558,6 +567,37 @@ function connect(){
 	});
 
 	saveSettings();
+	updateNamespaceGUI();
+}
+
+function updateNamespaceGUI() {
+	const seen = new Set(Object.values(markers).map(m => m.ns || ''));
+
+	namespaceDiv.innerHTML = '';
+	for (const ns of [...seen].sort()) {
+		const label = ns === '' ? 'No namespace' : ns;
+		const checkbox = document.createElement('input');
+		checkbox.type = 'checkbox';
+		checkbox.id = `{uniqueID}_ns_${ns}`;
+		checkbox.checked = !disabled_namespaces.has(ns);
+		checkbox.addEventListener('change', (e) => {
+			if (e.target.checked)
+				disabled_namespaces.delete(ns);
+			else
+				disabled_namespaces.add(ns);
+			saveSettings();
+			drawMarkers();
+		});
+		const labelEl = document.createElement('label');
+		labelEl.htmlFor = checkbox.id;
+		labelEl.textContent = ` ${label}`;
+		const div = document.createElement('div');
+		div.classList.add('tf_label');
+		div.appendChild(checkbox);
+		div.appendChild(labelEl);
+		div.classList.add('param_toggle_label');
+		namespaceDiv.appendChild(div);
+	}
 }
 
 async function loadTopics(){
@@ -596,6 +636,7 @@ selectionbox.addEventListener("click", (event) => {
 
 icon.addEventListener("click", (event) => {
 	loadTopics();
+	updateNamespaceGUI();
 });
 
 loadTopics();

--- a/vizanti_server/public/templates/markerarray/markerarray_script.js
+++ b/vizanti_server/public/templates/markerarray/markerarray_script.js
@@ -149,6 +149,9 @@ async function drawMarkers(){
 	}
 
 	function drawCubeList(marker, size) {
+		if (!marker.points || marker.points.length === 0)
+			return;
+
 		ctx.scale(marker.scale.x, marker.scale.y);
 
 		const sizeHalf = size / 2;
@@ -211,6 +214,8 @@ async function drawMarkers(){
 	}
 
 	function drawLine(marker, size){
+		if (!marker.points || marker.points.length === 0)
+			return;
 
 		if(!marker.hasOwnProperty("colors") || marker.colors.length == 0)
 			ctx.strokeStyle = rgbaToFillColor(marker.color);
@@ -234,6 +239,9 @@ async function drawMarkers(){
 	}
 
 	function drawLineList(marker, size){
+		if (!marker.points || marker.points.length === 0)
+			return;
+
 		ctx.lineWidth = parseInt(marker.scale.x*size);
 
 		// Draw lines between pairs of points: 0-1, 2-3, 4-5, etc.
@@ -265,6 +273,9 @@ async function drawMarkers(){
 	}
 
 	function drawSphereList(marker, size) {
+		if (!marker.points || marker.points.length === 0)
+			return;
+
 		const radius = (size * marker.scale.x) / 2; // Use scale.x for sphere diameter
 		
 		marker.points.forEach((point, index) => {
@@ -319,7 +330,8 @@ async function drawMarkers(){
 
 	function drawTriangleList(marker, size) {
 		const tris = marker.triangles;
-		if (!tris || tris.length === 0) return;
+		if (!tris || tris.length === 0)
+			return;
 
 		// Fast path: single color
 		if (marker.trianglesUniformColor) {

--- a/vizanti_server/public/templates/markerarray/markerarray_script.js
+++ b/vizanti_server/public/templates/markerarray/markerarray_script.js
@@ -290,6 +290,50 @@ async function drawMarkers(){
 		}
 	}
 
+	function drawTriangleList2(marker, size) {
+		const points = marker.transformedPoints;
+		const colors = marker.colors;
+		const hasVertexColors = colors && colors.length === points.length;
+		const hasFaceColors = colors && colors.length === points.length / 3;
+		const globalAlpha = marker.color.a > 0 ? marker.color.a : 1.0;
+
+		for (let i = 0; i < points.length - 2; i += 3) {
+			const p0 = points[i], p1 = points[i + 1], p2 = points[i + 2];
+
+			if (hasVertexColors) {
+				const c = colors[i];
+				ctx.fillStyle = `rgba(${Math.round(c.r*255)}, ${Math.round(c.g*255)}, ${Math.round(c.b*255)}, ${globalAlpha * c.a})`;
+			} else if (hasFaceColors) {
+				const c = colors[i / 3];
+				ctx.fillStyle = `rgba(${Math.round(c.r*255)}, ${Math.round(c.g*255)}, ${Math.round(c.b*255)}, ${globalAlpha * c.a})`;
+			} else {
+				ctx.fillStyle = rgbaToFillColor(marker.color);
+			}
+
+			ctx.beginPath();
+			ctx.moveTo(p0.x * size, -p0.y * size);
+			ctx.lineTo(p1.x * size, -p1.y * size);
+			ctx.lineTo(p2.x * size, -p2.y * size);
+			ctx.closePath();
+			ctx.fill();
+		}
+	}
+
+	function drawTriangleList(marker, size) {
+		const tris = marker.triangles;
+		if (!tris) return;
+
+		for (const tri of tris) {
+			ctx.fillStyle = tri.color;
+
+			ctx.beginPath();
+			ctx.moveTo(tri.p0.x * size, -tri.p0.y * size);
+			ctx.lineTo(tri.p1.x * size, -tri.p1.y * size);
+			ctx.lineTo(tri.p2.x * size, -tri.p2.y * size);
+			ctx.closePath();
+			ctx.fill();
+		}
+	}
 
 
 	const unit = view.getMapUnitsInPixels(1.0);
@@ -312,9 +356,11 @@ async function drawMarkers(){
 		if(!frame)
 			continue;
 
-		//skip old markers
-		if((current_time - marker.stamp) / 1000.0 > marker.lifetime.sec + marker.lifetime.nanosec*1e-9)
-			continue;
+
+		//skip old markers (only if lifetime is not 0/infinite)
+        const isInfiniteLifetime = marker.lifetime.sec === 0 && marker.lifetime.nanosec === 0;
+        if (!isInfiniteLifetime && (current_time - marker.stamp) / 1000.0 > marker.lifetime.sec + marker.lifetime.nanosec * 1e-9)
+            continue;
 
 		const pos = view.fixedToScreen({
 			x: marker.transformed.translation.x,
@@ -337,7 +383,7 @@ async function drawMarkers(){
 			case 8: status.setWarn("POINTS markers are not supported yet."); break; //POINTS=8
 			case 9: drawText(marker, unit); break;//TEXT_VIEW_FACING=9
 			case 10: status.setWarn("MESH_RESOURCE markers are not supported yet."); break; //MESH_RESOURCE=10
-			case 11: status.setWarn("TRIANGLE_LIST markers are not supported yet."); break; //TRIANGLE_LIST=11
+			case 11: ctx.setTransform(1, 0, 0, 1, pos.x, pos.y); drawTriangleList(marker, unit); break; //TRIANGLE_LIST=11
 		}
 	}
 }
@@ -398,6 +444,71 @@ function connect(){
 				m.pose.position, 
 				m.pose.orientation
 			);
+
+			//preprocess triangle_lists for correct 3D rotation and colour
+			if (m.type === 11 && m.points && m.points.length > 0) {
+				const {x, y, z, w} = m.transformed.rotation;
+
+				//rotate and scale matrix
+				const r00 = 1 - 2*(y*y + z*z);
+				const r01 = 2*(x*y - w*z);
+				const r02 = 2*(x*z + w*y);
+				const r10 = 2*(x*y + w*z);
+				const r11 = 1 - 2*(x*x + z*z);
+				const r12 = 2*(y*z - w*x);
+				const r20 = 2*(x*z - w*y);
+				const r21 = 2*(y*z + w*x);
+				const r22 = 1 - 2*(x*x + y*y);
+
+				const hasVertexColors = m.colors && m.colors.length === m.points.length;
+				const hasFaceColors = m.colors && m.colors.length === m.points.length / 3;
+				const globalAlpha = m.color.a > 0 ? m.color.a : 1.0;
+
+				const triangles = [];
+				for (let i = 0; i < m.points.length - 2; i += 3) {
+					const pts = [];
+
+					for (let j = 0; j < 3; j++) {
+						const p = m.points[i + j];
+
+						const sx = p.x * m.scale.x;
+						const sy = p.y * m.scale.y;
+						const sz = p.z * m.scale.z;
+
+						const rx = r00*sx + r01*sy + r02*sz;
+						const ry = r10*sx + r11*sy + r12*sz;
+						const rz = r20*sx + r21*sy + r22*sz;
+
+						pts.push({ x: rx, y: ry, z: rz });
+					}
+
+					const avgZ = (pts[0].z + pts[1].z + pts[2].z) / 3;
+
+					let color;
+					if (hasVertexColors) {
+						const c = m.colors[i];
+						color = `rgba(${Math.round(c.r*255)}, ${Math.round(c.g*255)}, ${Math.round(c.b*255)}, ${globalAlpha * c.a})`;
+					}else if (hasFaceColors) {
+						const c = m.colors[i / 3];
+						color = `rgba(${Math.round(c.r*255)}, ${Math.round(c.g*255)}, ${Math.round(c.b*255)}, ${globalAlpha * c.a})`;
+					}else {
+						color = rgbaToFillColor(m.color);
+					}
+
+					triangles.push({
+						p0: pts[0],
+						p1: pts[1],
+						p2: pts[2],
+						avgZ,
+						color
+					});
+				}
+
+				// Z sorting (back → front)
+				triangles.sort((a, b) => a.avgZ - b.avgZ);
+
+				m.triangles = triangles;
+			}
 
 			m.stamp = new Date();	
 			markers[id] = m;

--- a/vizanti_server/public/templates/markerarray/markerarray_script.js
+++ b/vizanti_server/public/templates/markerarray/markerarray_script.js
@@ -321,8 +321,25 @@ async function drawMarkers(){
 
 	function drawTriangleList(marker, size) {
 		const tris = marker.triangles;
-		if (!tris) return;
+		if (!tris || tris.length === 0) return;
 
+		// Fast path: single color
+		if (marker.trianglesUniformColor) {
+			ctx.fillStyle = marker.triangles[0].color;
+			ctx.beginPath();
+
+			for (const tri of tris) {
+				ctx.moveTo(tri.p0.x * size, -tri.p0.y * size);
+				ctx.lineTo(tri.p1.x * size, -tri.p1.y * size);
+				ctx.lineTo(tri.p2.x * size, -tri.p2.y * size);
+				ctx.closePath();
+			}
+
+			ctx.fill();
+			return;
+		}
+
+		// Fallback: per-triangle color
 		for (const tri of tris) {
 			ctx.fillStyle = tri.color;
 
@@ -504,9 +521,23 @@ function connect(){
 					});
 				}
 
-				// Z sorting (back → front)
-				triangles.sort((a, b) => a.avgZ - b.avgZ);
+				//can we render the whole thing in one draw call?
+				let uniformColor = true;
+				let firstColor = triangles.length > 0 ? triangles[0].color : null;
 
+				for (let i = 1; i < triangles.length; i++) {
+					if (triangles[i].color !== firstColor) {
+						uniformColor = false;
+						break;
+					}
+				}
+
+				// Z sorting (back → front), only if there's different colours
+				if (!uniformColor){
+					triangles.sort((a, b) => a.avgZ - b.avgZ);
+				}
+
+				m.isUniformColor = uniformColor;
 				m.triangles = triangles;
 			}
 


### PR DESCRIPTION
Fixes two major markerarray rendering issues:
- duration=0 markers got deleted immediately instead of being persistent
- if a point list is not specified for a marker type that uses it, the renderer crashed (aka slam toolbox graph visualization now works)

Added triangle list handling:

https://github.com/user-attachments/assets/cdf148c0-f46a-43d1-bafa-5616b5a932f7

Added namespace handling and opacity:

<img width="751" height="656" alt="image" src="https://github.com/user-attachments/assets/7cbec030-55e7-429b-8a62-d183f586f583" />

A bootstrapping fallback for rendering an OccupancyGrid published in a missing "map" frame with an identity transform, so an initialpose can be sent and nav2 + amcl can work without a preset pose.

Addresses #178, #182 and #179.
