### PR TITLE
Tile downloading rework, TF timestamp matching, various fixes (ROS 1)

### DIFF
--- a/public/js/modules/database.js
+++ b/public/js/modules/database.js
@@ -6,11 +6,18 @@ export class IndexedDatabase {
 
 	async openDB() {
 		return new Promise((resolve, reject) => {
-			const request = indexedDB.open("vizantiDB", 1);
+			const request = indexedDB.open("vizantiDB", 2);
 
 			request.onupgradeneeded = (event) => {
 				const db = event.target.result;
-				db.createObjectStore(this.storeName);
+
+				//yeah, not great, but can't really create stores outside upgrade callbacks
+				if (!db.objectStoreNames.contains("odom_history")) {
+					db.createObjectStore("odom_history");
+				}
+				if (!db.objectStoreNames.contains("tile_data")) {
+					db.createObjectStore("tile_data");
+				}
 			};
 
 			request.onsuccess = (event) => {

--- a/public/js/modules/navsat.js
+++ b/public/js/modules/navsat.js
@@ -96,7 +96,7 @@ export class Navsat {
 					const pending = Array.from(this.download_queue).filter(url => !this.currently_downloading.has(url)).slice(0, slots);
 					for (const tile_url of pending) {
 						this.currently_downloading.add(tile_url);
-						console.log(this.currently_downloading)
+						//console.log(this.currently_downloading)
 						this.attemptDownload(tile_url);
 					}
 				}

--- a/public/js/modules/navsat.js
+++ b/public/js/modules/navsat.js
@@ -57,7 +57,6 @@ export class Navsat {
 		this.tile_size = 256;
 		this.live_cache = {};
 		this.queue = new Set();
-		this.queue_history = new Set();
 
 		this.download_queue = new Set();
 		this.currently_downloading = new Set();
@@ -96,7 +95,6 @@ export class Navsat {
 					const pending = Array.from(this.download_queue).filter(url => !this.currently_downloading.has(url)).slice(0, slots);
 					for (const tile_url of pending) {
 						this.currently_downloading.add(tile_url);
-						console.log(this.currently_downloading)
 						this.attemptDownload(tile_url);
 					}
 				}
@@ -126,26 +124,22 @@ export class Navsat {
 		if (attempt < MAX_ATTEMPTS - 1) {
 			setTimeout(() => this.attemptDownload(tile_url, attempt + 1), 1000 * (attempt + 1));
 		} else {
-			// give up, remove from all queues so it can be re-enqueued next session or after clear
+			// give up, remove from all queues so it can be re-enqueued
 			this.download_queue.delete(tile_url);
 			this.currently_downloading.delete(tile_url);
-			this.queue_history.delete(tile_url); // allow retry after zoom change
 		}
 	}
 
-
 	enqueue(keyurl) {
-		if (this.queue_history.has(keyurl))
+		if (this.live_cache[keyurl] !== undefined || this.queue.has(keyurl) || this.download_queue.has(keyurl) || this.currently_downloading.has(keyurl))
 			return;
 
-		this.queue_history.add(keyurl);
 		this.queue.add(keyurl);
 		this.kickLoadLoop();
 	}
 
 	clear_queue() {
 		this.queue = new Set();
-		this.queue_history = new Set();
 		this.download_queue = new Set();
 		this.currently_downloading = new Set();
 	}
@@ -207,6 +201,6 @@ export class Navsat {
 		const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
 		const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 		return R * c;
-	}	
+	}
 }
 export let navsat = new Navsat();

--- a/public/js/modules/navsat.js
+++ b/public/js/modules/navsat.js
@@ -62,76 +62,92 @@ export class Navsat {
 		this.download_queue = new Set();
 		this.currently_downloading = new Set();
 
-		this.loadingloop = async ()=>{
+		this.MAX_CONCURRENT_DOWNLOADS = 6;
+		this.loopRunning = false;
 
-			let items = Array.from(this.queue);
-			for(let tile_url of items){
-				
-				//we already got it?
-				if(this.live_cache[tile_url] !== undefined){
-					this.queue.delete(tile_url);
-					continue;
+		this.kickLoadLoop = async () => {
+			if (this.loopRunning)
+				return;
+
+			this.loopRunning = true;
+			while (this.queue.size > 0 || this.download_queue.size > 0) {
+
+				if (this.queue.size > 0) {
+					const dbChecks = Array.from(this.queue).map(async (tile_url) => {
+						if (this.live_cache[tile_url] !== undefined) {
+							this.queue.delete(tile_url);
+							return;
+						}
+						if (Boolean(await db.keyExists(tile_url))) {
+							const data = await db.getObject(tile_url);
+							this.live_cache[tile_url] = await dataToImage(data);
+							this.queue.delete(tile_url);
+							window.dispatchEvent(new Event("navsat_tilecache_updated"));
+							return;
+						}
+						this.download_queue.add(tile_url);
+						this.queue.delete(tile_url);
+					});
+					await Promise.all(dbChecks);
 				}
 
-				//check the indexed DB
-				if(Boolean(await db.keyExists(tile_url))){
-					const data = await db.getObject(tile_url);
-					this.live_cache[tile_url] = await dataToImage(data);
-					this.queue.delete(tile_url);
-					window.dispatchEvent(new Event("navsat_tilecache_updated"));
-					continue;
+				const slots = this.MAX_CONCURRENT_DOWNLOADS - this.currently_downloading.size;
+				if (slots > 0) {
+					const pending = Array.from(this.download_queue).filter(url => !this.currently_downloading.has(url)).slice(0, slots);
+					for (const tile_url of pending) {
+						this.currently_downloading.add(tile_url);
+						console.log(this.currently_downloading)
+						this.attemptDownload(tile_url);
+					}
 				}
 
-				//hit up the CDN
-				this.download_queue.add(tile_url);
+				// yield to the event loop between batches so we don't block rendering
+				await new Promise(resolve => setTimeout(resolve, 0));
 			}
 
-			setTimeout(this.loadingloop, 100);
-		}
-		this.loadingloop();
-
-		this.downloadingloop = async ()=>{
-
-			const attemptDownload = async (tile_url) => {
-				//download from tile server, in case there's no internet we don't hang forever
-				const timeout = new Promise(resolve => setTimeout(() => resolve(undefined), 4000));
-				const data = await Promise.race([imageToDataURL(tile_url), timeout]);
-			
-				if (data) {
-					await db.setObject(tile_url, data);
-					this.live_cache[tile_url] = await dataToImage(data);
-					this.download_queue.delete(tile_url);
-					window.dispatchEvent(new Event("navsat_tilecache_updated"));
-				}
-
-				this.currently_downloading.delete(tile_url);
-			}
-			
-			// Inside your loop
-			let items = Array.from(this.download_queue);
-			for (let tile_url of items) {
-				if(tile_url && !this.currently_downloading.has(tile_url)){
-					this.currently_downloading.add(tile_url);
-					attemptDownload(tile_url);
-				}
-			}
-			setTimeout(this.downloadingloop, 500);
-		}
-		this.downloadingloop();
+			this.loopRunning = false;
+		};
 	}
 
-	async enqueue(keyurl){
-		if(this.queue_history.has(keyurl))
+	async attemptDownload(tile_url, attempt = 0) {
+		const MAX_ATTEMPTS = 3;
+		const timeout = new Promise(resolve => setTimeout(() => resolve(undefined), 4000));
+		const data = await Promise.race([imageToDataURL(tile_url), timeout]);
+
+		if (data) {
+			await db.setObject(tile_url, data);
+			this.live_cache[tile_url] = await dataToImage(data);
+			this.download_queue.delete(tile_url);
+			this.currently_downloading.delete(tile_url);
+			window.dispatchEvent(new Event("navsat_tilecache_updated"));
+			return;
+		}
+
+		if (attempt < MAX_ATTEMPTS - 1) {
+			setTimeout(() => this.attemptDownload(tile_url, attempt + 1), 1000 * (attempt + 1));
+		} else {
+			// give up, remove from all queues so it can be re-enqueued next session or after clear
+			this.download_queue.delete(tile_url);
+			this.currently_downloading.delete(tile_url);
+			this.queue_history.delete(tile_url); // allow retry after zoom change
+		}
+	}
+
+
+	enqueue(keyurl) {
+		if (this.queue_history.has(keyurl))
 			return;
 
 		this.queue_history.add(keyurl);
 		this.queue.add(keyurl);
+		this.kickLoadLoop();
 	}
 
-	async clear_queue(keyurl){
+	clear_queue() {
 		this.queue = new Set();
 		this.queue_history = new Set();
 		this.download_queue = new Set();
+		this.currently_downloading = new Set();
 	}
 
 	//https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames

--- a/public/js/modules/tf.js
+++ b/public/js/modules/tf.js
@@ -153,7 +153,6 @@ export class TF {
 			q.pop();
 		}
 
-		if (common === null) return null;
 		return p.concat(common, q.reverse());
 	}
 
@@ -246,8 +245,6 @@ export class TF {
 			return { translation: outputVector, rotation: outputQuat };
 
 		const path = this.findPath(sourceFrame, targetFrame);
-
-		if (!path) return null;
 
 		for (let i = 0; i < path.length - 1; i++) {
 			let source = this.transforms[path[i]];

--- a/public/js/modules/tf.js
+++ b/public/js/modules/tf.js
@@ -1,66 +1,53 @@
 import { rosbridge } from './rosbridge.js';
 
-/* class TimeStampedData {
-	constructor(maxLength) {
-		this.maxLength = maxLength;
-		this.data = [];
-		this.index = new Map();
+export function applyRotation(vector, r, inverse) {
+	if (inverse)
+		r = r.inverse();
+
+	const v = r.rotateVector([vector.x, vector.y, vector.z]);
+	return { x: v[0], y: v[1], z: v[2] };
+}
+
+// Fixed-size ring buffer storing { secs, nsecs, transform } entries per frame.
+// Oldest entry is overwritten once capacity is reached.
+class TransformRingBuffer {
+	constructor(capacity) {
+		this.capacity = capacity;
+		this.buf = new Array(capacity);
+		this.head = 0; // next write position
+		this.size = 0;
 	}
 
-	getKey({ secs, nsecs }) {
-		// Use the provided data structure to form a unique key
-		// The precision should be enough for up to 1ns resolution over approximately 285 years.
-		return secs * 1e9 + nsecs;
+	push(secs, nsecs, transform) {
+		this.buf[this.head] = { t: secs + nsecs * 1e-9, transform };
+		this.head = (this.head + 1) % this.capacity;
+		if (this.size < this.capacity) this.size++;
 	}
 
-	add(key, value) {
-		const timestampKey = this.getKey(key);
+	// Returns the transform whose timestamp is closest to the given stamp.
+	// Falls back to the most recently pushed entry if called with no arguments.
+	// Full scan (no early exit) handles non-monotonic clocks (e.g. rosbag restart).
+	nearest(secs, nsecs) {
+		if (this.size === 0) return null;
 
-		// If we're at maximum capacity, remove the oldest item
-		if (this.data.length >= this.maxLength) {
-			const oldestKey = this.getKey(this.data[0].key);
-			this.index.delete(oldestKey);
-			this.data.shift();
+		const latest = (this.head - 1 + this.capacity) % this.capacity;
+
+		if (secs == null || nsecs == null) return this.buf[latest].transform;
+
+		const target = secs + nsecs * 1e-9;
+		let bestIdx = latest;
+		let bestDist = Infinity;
+
+		for (let i = 0; i < this.size; i++) {
+			const idx = (this.head - 1 - i + this.capacity) % this.capacity;
+			const dist = Math.abs(this.buf[idx].t - target);
+			if (dist < bestDist) {
+				bestDist = dist;
+				bestIdx = idx;
+			}
 		}
 
-		// Add the new item
-		this.data.push({ key, value });
-		this.index.set(timestampKey, value);
-	}
-
-	get(key) {
-		const timestampKey = this.getKey(key);
-		return this.index.get(timestampKey);
-	}
-
-	find(key) {
-		const timestampKey = this.getKey(key);
-		const keys = Array.from(this.index.keys());
-
-		console.log("Find: ",timestampKey," in ",keys);
-
-		// Find the key closest to the input timestamp
-		const closestKey = keys.reduce((prev, curr) => {
-			return (Math.abs(curr - timestampKey) < Math.abs(prev - timestampKey) ? curr : prev);
-		});
-		return this.index.get(closestKey);
-	}
-} */
-
-export function applyRotation(vector, r, inverse){
-	if(inverse)
-		r = r.inverse();
-		
-	const v = r.rotateVector([
-		vector.x,
-		vector.y,
-		vector.z
-	]);
-
-	return {
-		x: v[0],
-		y: v[1],
-		z: v[2]
+		return this.buf[bestIdx].transform;
 	}
 }
 
@@ -70,7 +57,7 @@ export class TF {
 
 		this.transforms = {};
 		this.absoluteTransforms = {};
-		//this.absoluteTransformsHistory = new TimeStampedData(20);
+		this.absoluteTransformBuffers = {};
 		this.frame_list = new Set();
 		this.frame_timestamps = {};
 		this.frame_headerstamps = {};
@@ -84,17 +71,14 @@ export class TF {
 		});
 
 		this.tf_listener = this.tf_topic.subscribe((msg) => {
-
-			//local timestamping for removing inactive frames
 			const time_stamp = new Date();
 			msg.transforms.forEach((pose) => {
 				this.frame_timestamps[pose.child_frame_id] = time_stamp;
 				this.frame_timestamps[pose.header.frame_id] = time_stamp;
-				this.updateFrameTimestamp(pose.child_frame_id,pose.header.stamp);
-			})
+				this.updateFrameTimestamp(pose.child_frame_id, pose.header.stamp);
+			});
 
 			this.updateTransforms(msg.transforms);
-			//this.absoluteTransformsHistory.add(msg.transforms[0].header.stamp, this.absoluteTransforms);
 		});
 
 		this.tf_static_topic = new ROSLIB.Topic({
@@ -110,98 +94,43 @@ export class TF {
 
 		this.event_timestamp = performance.now();
 
-		window.addEventListener("view_changed", ()=> {
+		window.addEventListener("view_changed", () => {
 			this.event_timestamp = performance.now();
 		});
 
-		//removing inactive TF frames
-		setInterval(()=>{
-			const now = new Date()
+		setInterval(() => {
+			const now = new Date();
 			let deleted_anything = false;
 			for (const [frame_id, time_stamp] of Object.entries(this.frame_timestamps)) {
-				if(now - time_stamp > 1000 * 100){
+				if (now - time_stamp > 1000 * 100) {
 					this.frame_list.delete(frame_id);
 					delete this.transforms[frame_id];
 					delete this.absoluteTransforms[frame_id];
+					delete this.absoluteTransformBuffers[frame_id];
 					delete this.frame_headerstamps[frame_id];
+					delete this.frame_timestamps[frame_id];
 					deleted_anything = true;
 				}
 			}
 
-			if(deleted_anything){
+			if (deleted_anything)
 				window.dispatchEvent(new Event("tf_changed"));
-			}
-		},5000)
+		}, 5000);
 	}
 
-	updateFrameTimestamp(frame_id, stamp){
+	updateFrameTimestamp(frame_id, stamp) {
 		this.frame_headerstamps[frame_id] = stamp;
 
-		//update all child frames that were moved as well
 		for (const frame in this.transforms) {
 			if (this.transforms[frame].parent === frame_id) {
-				this.frame_headerstamps[frame] = stamp; //we assume that the frame we just got is newer than what we already have
+				this.frame_headerstamps[frame] = stamp;
 				this.updateFrameTimestamp(frame, stamp);
 			}
 		}
 	}
 
-
-	/* interpolateTransforms() {
-		if (this.lastReceivedTransforms !== null && this.previousTransforms !== null && performance.now() - this.lastReceivedTime > 15) {
-			const prevdelta = (this.lastReceivedTime - this.previousTime) / 1000;
-			let delta = ((performance.now() - this.lastReceivedTime) / 1000) / prevdelta;
-
-			console.log("interpolation")
-
-			delta *= 0.005;
-
-			const transformsMap = new Map();
-			this.previousTransforms.forEach(transform => {
-				transformsMap.set(transform.child_frame_id, { previous: transform });
-			});
-	
-			this.lastReceivedTransforms.forEach(transform => {
-				if (transformsMap.has(transform.child_frame_id)) {
-					transformsMap.get(transform.child_frame_id).current = transform;
-				}
-			});
-	
-			const interpolatedTransforms = [];
-	
-			transformsMap.forEach(({ previous, current }, child_frame_id) => {
-				if (current) {
-					const positionDelta = {
-						x: current.transform.translation.x - previous.transform.translation.x,
-						y: current.transform.translation.y - previous.transform.translation.y
-					};
-					const velocity = {
-						x: positionDelta.x * delta,
-						y: positionDelta.y * delta,
-					};
-
-					const interpolatedTransform = {
-						child_frame_id: child_frame_id,
-						header: current.header,
-						transform: {
-							translation: {
-								x: current.transform.translation.x + velocity.x,
-								y: current.transform.translation.y + velocity.y,
-								z: current.transform.translation.z
-							},
-							rotation: current.transform.rotation
-						}
-					};
-					interpolatedTransforms.push(interpolatedTransform);
-				}
-			});
-	
-			this.updateTransforms(interpolatedTransforms);
-		}
-	} */
-
-	async sendUpdateEvent(){
-		if(performance.now() - this.event_timestamp > 12){
+	sendUpdateEvent() {
+		if (performance.now() - this.event_timestamp > 12) {
 			window.dispatchEvent(new Event("tf_changed"));
 			this.event_timestamp = performance.now();
 		}
@@ -209,39 +138,34 @@ export class TF {
 
 	getPathToRoot(frame) {
 		const currentFrame = this.transforms[frame];
-		if (!currentFrame) {
-			return [frame];
-		}
-		if (!currentFrame.parent) {
-			return [frame];
-		}
+		if (!currentFrame) return [frame];
+		if (!currentFrame.parent) return [frame];
 		return [frame].concat(this.getPathToRoot(currentFrame.parent));
 	}
-	
+
 	findPath(startFrame, endFrame) {
 		const p = this.getPathToRoot(startFrame);
 		const q = this.getPathToRoot(endFrame);
-	
+
 		let common = null;
 		while (p.length > 0 && q.length > 0 && p[p.length - 1] === q[q.length - 1]) {
 			common = p.pop();
 			q.pop();
 		}
-	
+
+		if (common === null) return null;
 		return p.concat(common, q.reverse());
 	}
 
 	updateTransforms(newtransforms) {
 		newtransforms.forEach((pose) => {
-
 			const childFrameId = pose.child_frame_id;
 			const parentFrameId = pose.header.frame_id;
 
 			this.frame_list.add(childFrameId);
 			this.frame_list.add(parentFrameId);
-
 			this.frame_list = new Set([...this.frame_list].sort());
-	
+
 			this.transforms[childFrameId] = {
 				translation: pose.transform.translation,
 				rotation: new Quaternion(
@@ -260,69 +184,98 @@ export class TF {
 
 	setFixedFrame(newframe) {
 		this.fixed_frame = newframe;
+		this.absoluteTransformBuffers = {};
 		this.recalculateAbsoluteTransforms();
 		window.dispatchEvent(new Event("tf_fixed_frame_changed"));
 	}
 
 	recalculateAbsoluteTransforms() {
 		for (const key of this.frame_list.values()) {
-			this.absoluteTransforms[key] = this.transformPose(key, this.fixed_frame, {x: 0, y:0, z:0}, new Quaternion());
+			const transform = this.transformPose(key, this.fixed_frame, { x: 0, y: 0, z: 0 }, new Quaternion());
+			this.absoluteTransforms[key] = transform;
+
+			if (!this.absoluteTransformBuffers[key])
+				this.absoluteTransformBuffers[key] = new TransformRingBuffer(16);
+
+			const stamp = this.frame_headerstamps[key];
+			if (stamp)
+				this.absoluteTransformBuffers[key].push(stamp.secs, stamp.nsecs, transform);
 		}
 	}
 
-	getZeroFrame(){
+	getZeroFrame() {
 		return {
-			translation:{x: 0, y:0, z:0},
+			translation: { x: 0, y: 0, z: 0 },
 			rotation: new Quaternion()
-		}
+		};
+	}
+
+	getAbsoluteTransform(header) {
+		const buf = this.absoluteTransformBuffers[header.frame_id];
+		if (!buf)
+			return this.absoluteTransforms[header.frame_id];
+		return buf.nearest(header.stamp?.secs, header.stamp?.nsecs) ?? this.absoluteTransforms[header.frame_id];
+	}
+
+	// Timestamp-aware drop-in for transformPose(frame, fixed_frame, position, orientation).
+	// Applies the offset pose on top of the buffered absolute transform for header.frame_id.
+	transformPoseStamped(header, position, orientation) {
+		const abs = this.getAbsoluteTransform(header);
+		if (!abs)
+			return null;
+
+		const inputQuat = new Quaternion(orientation);
+
+		// Rotate the local offset into fixed-frame space, then add the frame's fixed-frame origin.
+		const rotated = applyRotation(position, abs.rotation, false);
+		return {
+			translation: {
+				x: abs.translation.x + rotated.x,
+				y: abs.translation.y + rotated.y,
+				z: abs.translation.z + rotated.z
+			},
+			rotation: abs.rotation.mul(inputQuat)
+		};
 	}
 
 	transformPose(sourceFrame, targetFrame, inputVector, inputQuat) {
-
 		let outputVector = Object.assign({}, inputVector);
 		let outputQuat = new Quaternion(inputQuat);
 
-		if(sourceFrame == targetFrame){
-			return {
-				translation: outputVector,
-				rotation: outputQuat
-			};
-		}
+		if (sourceFrame == targetFrame)
+			return { translation: outputVector, rotation: outputQuat };
 
 		const path = this.findPath(sourceFrame, targetFrame);
+
+		if (!path) return null;
 
 		for (let i = 0; i < path.length - 1; i++) {
 			let source = this.transforms[path[i]];
 
-			if(!source)
+			if (!source)
 				source = this.getZeroFrame();
 
-			if(source.parent == path[i+1]){
+			if (source.parent == path[i + 1]) {
 				outputQuat = source.rotation.mul(outputQuat);
-	
 				outputVector = applyRotation(outputVector, source.rotation, false);
 				outputVector.x += source.translation.x;
 				outputVector.y += source.translation.y;
 				outputVector.z += source.translation.z;
-			}else{
-				source = this.transforms[path[i+1]];
+			} else {
+				source = this.transforms[path[i + 1]];
 
-				if(!source)
+				if (!source)
 					source = this.getZeroFrame();
 
 				outputQuat = source.rotation.inverse().mul(outputQuat);
-	
 				outputVector.x -= source.translation.x;
 				outputVector.y -= source.translation.y;
 				outputVector.z -= source.translation.z;
 				outputVector = applyRotation(outputVector, source.rotation, true);
 			}
 		}
-	
-		return {
-			translation: outputVector,
-			rotation: outputQuat
-		};
+
+		return { translation: outputVector, rotation: outputQuat };
 	}
 
 	getTimeStampDelta(timestamp1, timestamp2) {

--- a/public/js/modules/tf.js
+++ b/public/js/modules/tf.js
@@ -28,11 +28,13 @@ class TransformRingBuffer {
 	// Falls back to the most recently pushed entry if called with no arguments.
 	// Full scan (no early exit) handles non-monotonic clocks (e.g. rosbag restart).
 	nearest(secs, nsecs) {
-		if (this.size === 0) return null;
+		if (this.size === 0)
+			return null;
 
 		const latest = (this.head - 1 + this.capacity) % this.capacity;
 
-		if (secs == null || nsecs == null) return this.buf[latest].transform;
+		if (secs == null || nsecs == null)
+			return this.buf[latest].transform;
 
 		const target = secs + nsecs * 1e-9;
 		let bestIdx = latest;
@@ -220,8 +222,9 @@ export class TF {
 	// Applies the offset pose on top of the buffered absolute transform for header.frame_id.
 	transformPoseStamped(header, position, orientation) {
 		const abs = this.getAbsoluteTransform(header);
+		
 		if (!abs)
-			return null;
+			return this.getZeroFrame();
 
 		const inputQuat = new Quaternion(orientation);
 

--- a/public/js/modules/util.js
+++ b/public/js/modules/util.js
@@ -32,11 +32,7 @@ export function imageToDataURL(url) {
 			ctx.drawImage(img, 0, 0);
 			resolve(canvas.toDataURL());
 		};
-		img.onerror = (error) => {
-			setTimeout(() => {
-				img.src = url;
-			}, 1000);
-		};
+		img.onerror = () => reject(new Error(`Failed to load image: ${url}`));
 
 		img.src = url;
 	});

--- a/public/templates/add/add_modal.html
+++ b/public/templates/add/add_modal.html
@@ -180,9 +180,9 @@
 			</div>
 
 			<div class="widget_entry" onclick="addWidget('satelite','')" data-topic="sensor_msgs/NavSatFix">
-				<img src="assets/satelite.svg" alt="Satelite" class="card_icon">
+				<img src="assets/satelite.svg" alt="Satellite" class="card_icon">
 				<div class="card">
-					<b class="card_title">Satelite Tiles</b>
+					<b class="card_title">Satellite Tiles</b>
 					<p class="card_desc">sensor_msgs/NavSatFix</p>
 				</div>
 			</div>

--- a/public/templates/add/add_modal.html
+++ b/public/templates/add/add_modal.html
@@ -137,7 +137,7 @@
 				</div>
 			</div>
 
-			<div class="widget_entry" onclick="addWidget('altimeter','')" data-topic="std_msgs/Float32">
+			<div class="widget_entry" onclick="addWidget('altimeter','')">
 				<img src="assets/altimeter.svg" alt="Altimeter" class="card_icon">
 				<div class="card">
 					<b class="card_title">Altimeter</b>

--- a/public/templates/altimeter/altimeter_modal.html
+++ b/public/templates/altimeter/altimeter_modal.html
@@ -14,7 +14,13 @@
 			<option value='base_link'>base_link</option>
 		</select>
 
-		<div class="spacer"></div>
+		<p>Displays the Z value of the frame on a depth/altitude gauge. Inverted modes treat negative values to positive.</p>
+
+		<div class="live_data_display">
+			<p id="{uniqueID}_altitude_text">Altitude: ?</p>
+			<p id="{uniqueID}_target_text">Target: N/A</p>
+		</div>
+
 
 		<label for="{uniqueID}_mode">Display Mode:</label>
 		<select id="{uniqueID}_mode" name="topic">
@@ -31,14 +37,7 @@
 
 		<div class="spacer"></div>
 
-		<div class="live_data_display">
-			<p id="{uniqueID}_altitude_text">Altitude: ?</p>
-			<p id="{uniqueID}_target_text">Target: N/A</p>
-		</div>
-
-		Displays the Z value of the frame on a depth/altitude gauge. Inverted modes treat negative values to positive.
-
-		<div class="spacer"></div>
+		<hr class="dark_hr"/>
 
 		<h4>Click Target</h4>
 

--- a/public/templates/altimeter/altimeter_modal.html
+++ b/public/templates/altimeter/altimeter_modal.html
@@ -43,7 +43,7 @@
 
 		<p>Send a std_msgs/Float32 value to this topic.</p>
 
-		<p class="comment">If a topic is selected, then clicking the altimeter will mark the depth/alitude with a yellow flag and publish it.</p>
+		<p class="comment">If a topic is selected, then clicking the altimeter will mark the depth/altitude with a yellow flag and publish it.</p>
 
 		<label for="{uniqueID}_topic">Target topic:</label>
 		<select id="{uniqueID}_topic" name="topic">

--- a/public/templates/altimeter/altimeter_modal.html
+++ b/public/templates/altimeter/altimeter_modal.html
@@ -40,18 +40,17 @@
 
 		<div class="spacer"></div>
 
-		<h4>Send Target</h4>
-
-		<div class="spacer"></div>
-
-		<label for="{uniqueID}_topic">Value Topic:</label>
-		<select id="{uniqueID}_topic" name="topic">
-			<option value="/depth_tgt">/depth_tgt</option>
-		</select>
+		<h4>Click Target</h4>
 
 		<p>Send a std_msgs/Float32 value to this topic.</p>
 
-		<p class="comment">Clicking the altimeter will mark the depth/alitude with a yellow flag and publish it. Or click the button below and input it manually.</p>
+		<p class="comment">If a topic is selected, then clicking the altimeter will mark the depth/alitude with a yellow flag and publish it.</p>
+
+		<label for="{uniqueID}_topic">Target topic:</label>
+		<select id="{uniqueID}_topic" name="topic">
+		</select>
+
+		<div class="spacer"></div>
 
 		<button id="{uniqueID}_manual_target" class="export_button">Input and send target manually</button>
 

--- a/public/templates/altimeter/altimeter_script.js
+++ b/public/templates/altimeter/altimeter_script.js
@@ -23,7 +23,7 @@ let meters_smooth = 0;
 let target = NaN;
 
 let frame = "";
-let topic = getTopic("{uniqueID}");
+let topic = "";
 
 let float_topic = undefined;
 let listener = undefined;
@@ -96,7 +96,8 @@ function saveSettings(){
 function connect(){
 
 	if(topic == ""){
-		status.setWarn("Empty topic.");
+		target = NaN;
+		text_target.innerText = "Target: N/A";
 		return;
 	}
 
@@ -419,20 +420,17 @@ async function loadTopics(){
 
 	let topiclist = "";
 	result.forEach(element => {
-		topiclist += "<option value='"+element+"'>"+element+"</option>"
+		topiclist += "<option value='"+element+"'>"+element+"</option>";
 	});
+	topiclist += "<option value=''>(Disabled)</option>";
 	selectionbox.innerHTML = topiclist
 
-	if(topic == "")
-		topic = selectionbox.value;
-	else{
-		if(result.includes(topic)){
-			selectionbox.value = topic;
-		}else{
-			topiclist += "<option value='"+topic+"'>"+topic+"</option>"
-			selectionbox.innerHTML = topiclist
-			selectionbox.value = topic;
-		}
+	if(result.includes(topic) || topic == ""){
+		selectionbox.value = topic;
+	}else{
+		topiclist += "<option value='"+topic+"'>"+topic+"</option>"
+		selectionbox.innerHTML = topiclist
+		selectionbox.value = topic;
 	}
 
 	connect();
@@ -522,6 +520,9 @@ function onTargetStart(event) {
 }
 
 function onTargetEnd(event) {
+
+	if(topic == "")
+		return;
 
 	targeting_active = false;
 	document.removeEventListener('mouseup', onTargetEnd);

--- a/public/templates/battery/battery_modal.html
+++ b/public/templates/battery/battery_modal.html
@@ -12,7 +12,7 @@
 		</select>
 
 		<div class="live_data_display">
-			<p id="{uniqueID}_pecentage">Percentage: ?</p>
+			<p id="{uniqueID}_percentage">Percentage: ?</p>
 			<p id="{uniqueID}_voltage">Voltage: ?</p>
 			<p id="{uniqueID}_cell_voltage">Cell Voltages: ?</p>
 	

--- a/public/templates/battery/battery_script.js
+++ b/public/templates/battery/battery_script.js
@@ -76,7 +76,7 @@ const CHEMISTRY = [
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const icon = document.getElementById("{uniqueID}_icon").getElementsByTagName('img')[0];
 
-const text_percent = document.getElementById("{uniqueID}_pecentage");
+const text_percent = document.getElementById("{uniqueID}_percentage");
 const text_voltage = document.getElementById("{uniqueID}_voltage");
 const text_cell_voltage = document.getElementById("{uniqueID}_cell_voltage");
 const text_current = document.getElementById("{uniqueID}_current");

--- a/public/templates/grid/grid_modal.html
+++ b/public/templates/grid/grid_modal.html
@@ -41,7 +41,7 @@
 
 		<hr class="dark_hr"/>
 
-		<h4>Subdivison Style</h4>
+		<h4>Subdivision Style</h4>
 
 		<p class="comment">Each step can be divided further.</p>
 

--- a/public/templates/gridcells/gridcells_modal.html
+++ b/public/templates/gridcells/gridcells_modal.html
@@ -32,7 +32,7 @@
 		<label>Use Timestamp:</label>
 		<input type="checkbox" id="{uniqueID}_use_timestamp">	
 
-		<p class="comment">Rendering fixed objects at their published timestamp causes them to lag behind when focusing on frames other than the map frame. Rviz uses the latest timestamp instead, which this emulates. Enable for techincally correct rendering.</p>
+		<p class="comment">Rendering fixed objects at their published timestamp causes them to lag behind when focusing on frames other than the map frame. Rviz uses the latest timestamp instead, which this emulates. Enable for technically correct rendering.</p>
 
 		<hr class="dark_hr"/>
 

--- a/public/templates/gridcells/gridcells_script.js
+++ b/public/templates/gridcells/gridcells_script.js
@@ -101,7 +101,7 @@ async function drawCells() {
 	ctx.globalAlpha = opacitySlider.value;
 	ctx.fillStyle = colourpicker.value;
 
-	let tf_pose = timestampCheckbox.checked ? data.pose : tf.absoluteTransforms[data.msg.header.frame_id];
+	let tf_pose = timestampCheckbox.checked ? data.pose : tf.getAbsoluteTransform(data.msg.header);
 
 	if(!tf_pose){
 		return;

--- a/public/templates/map/map_modal.html
+++ b/public/templates/map/map_modal.html
@@ -37,7 +37,7 @@
 		<label>Use Timestamp:</label>
 		<input type="checkbox" id="{uniqueID}_use_timestamp">	
 
-		<p class="comment">Rendering maps at their published timestamp causes them to lag behind when focusing on frames other than the map frame. Rviz uses the latest timestamp instead, which this emulates. Enable for techincally correct rendering.</p>
+		<p class="comment">Rendering maps at their published timestamp causes them to lag behind when focusing on frames other than the map frame. Rviz uses the latest timestamp instead, which this emulates. Enable for technically correct rendering.</p>
 
 		<div class="spacer"></div>
 

--- a/public/templates/map/map_script.js
+++ b/public/templates/map/map_script.js
@@ -223,9 +223,8 @@ async function drawMap(){
 	let tf_pose = map_data.pose;
 
 	if(!timestampCheckbox.checked){
-		tf_pose = tf.transformPose(
-			map_data.header.frame_id,
-			tf.fixed_frame,
+		tf_pose = tf.transformPoseStamped(
+			map_data.header,
 			map_data.info.origin.position,
 			map_data.info.origin.orientation
 		);
@@ -317,10 +316,9 @@ function connect(){
 }
 
 function queueWorkerMsg(msg){
-	msg.pose = tf.transformPose(
-		msg.header.frame_id,
-		tf.fixed_frame,
-		msg.info.origin.position,
+	msg.pose = tf.transformPoseStamped(
+		msg.header,
+		msg.info.origin.position, 
 		msg.info.origin.orientation
 	);
 

--- a/public/templates/markerarray/markerarray_script.js
+++ b/public/templates/markerarray/markerarray_script.js
@@ -395,7 +395,7 @@ async function drawMarkers(){
 		
 		ctx.fillStyle = rgbaToFillColor(marker.color);
 
-		const frame = tf.absoluteTransforms[marker.header.frame_id];
+		const frame = tf.getAbsoluteTransform(marker.header);
 
 		if(!frame)
 			continue;
@@ -482,9 +482,8 @@ function connect(){
 				error = true;
 			}
 
-			m.transformed = tf.transformPose(
-				m.header.frame_id, 
-				tf.fixed_frame, 
+			m.transformed = tf.transformPoseStamped(
+				m.header,
 				m.pose.position, 
 				m.pose.orientation
 			);

--- a/public/templates/markerarray/markerarray_script.js
+++ b/public/templates/markerarray/markerarray_script.js
@@ -79,7 +79,6 @@ function saveSettings(){
 }
 
 
-
 //Rendering
 
 /* 
@@ -382,7 +381,6 @@ async function drawMarkers(){
 	if(opacitySlider.value == 0.0){
 		return;
 	}
-
 
 	let current_time = new Date();
 

--- a/public/templates/odom/odom_modal.html
+++ b/public/templates/odom/odom_modal.html
@@ -48,6 +48,10 @@
 
 		<div class="spacer"></div>
 
+		<button id="{uniqueID}_downloadcsv">Download as CSV</button>
+
+		<div class="spacer"></div>
+
 		<button id="{uniqueID}_clearhistory" style="background-color: rgb(104, 78, 31);">Clear history</button>
 
 		<div class="spacer"></div>

--- a/public/templates/odom/odom_modal.html
+++ b/public/templates/odom/odom_modal.html
@@ -11,7 +11,10 @@
 
 		<p>Track a TF link or nav_msgs/Odometry data.</p>
 
-		<hr class="dark_hr"/>
+		<div class="live_data_display">
+			<p id="{uniqueID}_points_text">Points: ?</p>
+			<p id="{uniqueID}_distance_text">Distance: ?</p>
+		</div>
 
 		<label for="{uniqueID}_colorpicker">Colour:</label>
 		<input type="color" value="#c43b00" id="{uniqueID}_colorpicker">
@@ -35,6 +38,13 @@
 
 		<label>Draw arrows:</label>
 		<input type="checkbox" checked id="{uniqueID}_draw_arrows">
+
+		<hr class="dark_hr"/>
+
+		<h4>Persistence</h4>
+
+		<label>Save history:</label>
+		<input type="checkbox" checked id="{uniqueID}_save_history">
 
 		<div class="spacer"></div>
 

--- a/public/templates/odom/odom_modal.html
+++ b/public/templates/odom/odom_modal.html
@@ -50,7 +50,7 @@
 
 		<button id="{uniqueID}_downloadcsv">Download as CSV</button>
 
-		<p class="comment">Export pose data as x, y, yaw for analisys, or to import as a waypoint mission.</p>
+		<p class="comment">Export pose data as x, y, yaw for analysis, or to import as a waypoint mission.</p>
 
 		<button id="{uniqueID}_clearhistory" style="background-color: rgb(104, 78, 31);">Clear history</button>
 

--- a/public/templates/odom/odom_modal.html
+++ b/public/templates/odom/odom_modal.html
@@ -19,7 +19,7 @@
 		<div class="spacer"></div>
 
 		<label for="{uniqueID}_history">History (N):</label>
-		<input type="number" value="200" step="1" min="2" max="10000" id="{uniqueID}_history">
+		<input type="number" value="200" step="1" min="2" max="50000" id="{uniqueID}_history">
 
 		<div class="spacer"></div>
 

--- a/public/templates/odom/odom_modal.html
+++ b/public/templates/odom/odom_modal.html
@@ -22,7 +22,7 @@
 		<div class="spacer"></div>
 
 		<label for="{uniqueID}_history">History (N):</label>
-		<input type="number" value="200" step="1" min="2" max="50000" id="{uniqueID}_history">
+		<input type="number" value="2000" step="1" min="2" max="50000" id="{uniqueID}_history">
 
 		<div class="spacer"></div>
 
@@ -46,11 +46,11 @@
 		<label>Save history:</label>
 		<input type="checkbox" checked id="{uniqueID}_save_history">
 
-		<div class="spacer"></div>
+		<p class="comment">Recorded data will reset upon page reload if saving is disabled.</p>
 
 		<button id="{uniqueID}_downloadcsv">Download as CSV</button>
 
-		<div class="spacer"></div>
+		<p class="comment">Export pose data as x, y, yaw for analisys, or to import as a waypoint mission.</p>
 
 		<button id="{uniqueID}_clearhistory" style="background-color: rgb(104, 78, 31);">Clear history</button>
 

--- a/public/templates/odom/odom_script.js
+++ b/public/templates/odom/odom_script.js
@@ -4,12 +4,17 @@ let rosbridgeModule = await import(`${base_url}/js/modules/rosbridge.js`);
 let persistentModule = await import(`${base_url}/js/modules/persistent.js`);
 let StatusModule = await import(`${base_url}/js/modules/status.js`);
 let utilModule = await import(`${base_url}/js/modules/util.js`);
+let dbModule = await import(`${base_url}/js/modules/database.js`);
 
 let view = viewModule.view;
 let tf = tfModule.tf;
 let rosbridge = rosbridgeModule.rosbridge;
 let settings = persistentModule.settings;
 let Status = StatusModule.Status;
+
+const db = new dbModule.IndexedDatabase('odom_history');
+await db.openDB();
+const DB_KEY = "odom_pose_history_{uniqueID}";
 
 let topic = getTopic("{uniqueID}");
 
@@ -29,6 +34,9 @@ let sample_array = [];
 let mode = "" //see setMode()
 let raw_target = "";
 
+const text_point_count = document.getElementById("{uniqueID}_points_text");
+const text_total_dist = document.getElementById("{uniqueID}_distance_text");
+
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const click_icon = document.getElementById("{uniqueID}_icon");
 const icon = click_icon.getElementsByTagName('object')[0];
@@ -44,6 +52,12 @@ drawarrows.addEventListener('change', ()=>{
 
 const drawpath = document.getElementById('{uniqueID}_draw_path');
 drawpath.addEventListener('change', ()=>{
+	saveSettings();
+	drawHistory();
+});
+
+const save_history = document.getElementById('{uniqueID}_save_history');
+save_history.addEventListener('change', ()=>{
 	saveSettings();
 	drawHistory();
 });
@@ -65,10 +79,8 @@ const historypicker = document.getElementById('{uniqueID}_history');
 historypicker.addEventListener("input", (event) =>{
 	saveSettings();
 
-	if(historypicker.value > 0){
-		while (sample_array.length > historypicker.value) {
-			sample_array.shift();
-		}
+	while (sample_array.length > historypicker.value) {
+		sample_array.shift();
 	}
 
 	drawHistory();
@@ -77,21 +89,28 @@ historypicker.addEventListener("input", (event) =>{
 const clearHistoryButton = document.getElementById("{uniqueID}_clearhistory");
 clearHistoryButton.addEventListener('click', ()=>{
 	sample_array = [];
+	points_since_flush = 0;
+	db.setObject(DB_KEY, null);
 });
 
 //Settings
 if(settings.hasOwnProperty("{uniqueID}")){
-	const loaded_data  = settings["{uniqueID}"];
+	const loaded_data = settings["{uniqueID}"];
 	topic = loaded_data.topic;
 
 	historypicker.value = loaded_data.history;
-	drawarrows.checked =  loaded_data.draw_arrows;
-	drawpath.checked =  loaded_data.draw_path;
+	drawarrows.checked = loaded_data.draw_arrows;
+	drawpath.checked = loaded_data.draw_path;
 	throttle.value = loaded_data.throttle;
 	colourpicker.value = loaded_data.color ?? "#54db67";
+	save_history.checked = loaded_data.save_history ?? true;
 	setMode();
 }else{
 	saveSettings();
+}
+
+if(save_history.checked){
+	await loadPoints();
 }
 
 //update the icon colour when it's loaded or when the image source changes
@@ -110,9 +129,30 @@ function saveSettings(){
 		color: colourpicker.value,
 		throttle: throttle.value,
 		draw_arrows: drawarrows.checked,
-		draw_path: drawpath.checked
+		draw_path: drawpath.checked,
+		save_history: save_history.checked
 	}
 	settings.save();
+}
+
+async function loadPoints(){
+	const stored = await db.getObject(DB_KEY);
+	if(stored instanceof Float32Array && stored.length % 3 === 0){
+		for(let i = 0; i < stored.length; i += 3){
+			sample_array.push({ x: stored[i], y: stored[i+1], yaw: stored[i+2] });
+		}
+		drawHistory();
+	}
+}
+
+function savePoints(){
+	const packed = new Float32Array(sample_array.length * 3);
+	for(let i = 0; i < sample_array.length; i++){
+		packed[i*3] = sample_array[i].x;
+		packed[i*3+1] = sample_array[i].y;
+		packed[i*3+2] = sample_array[i].yaw;
+	}
+	db.setObject(DB_KEY, packed);
 }
 
 //Rendering
@@ -179,6 +219,39 @@ async function drawHistory(){
 	}
 }
 
+
+function updateTextDisplay(){
+
+	function getDistance(posearray) {
+		if (!Array.isArray(posearray) || posearray.length < 2)
+			return 0;
+		
+		let dist = 0;
+		for (let i = 0; i < posearray.length - 1; i++) {
+			const pose1 = posearray[i];
+			const pose2 = posearray[i + 1];
+			const dx = pose2.x - pose1.x;
+			const dy = pose2.y - pose1.y;
+			dist += Math.sqrt(dx * dx + dy * dy);
+		}
+		return dist;
+	}
+
+	text_point_count.innerText = "Points: "+sample_array.length;
+	let dist = getDistance(sample_array)
+
+	if(dist > 1000.0){
+		dist /= 1000.0
+		text_total_dist.innerText = "Distance: "+dist.toFixed(3)+" km";
+	}else if(dist < 1.0){
+		dist *= 100.0
+		text_total_dist.innerText = "Distance: "+dist.toFixed(1)+" cm";
+	}else{
+		text_total_dist.innerText = "Distance: "+dist.toFixed(2)+" m";
+	}
+}
+
+let time_since_updated = Date.now();
 function appendPose(pose){
 	const pose2D = {
 		x: pose.translation.x,
@@ -198,10 +271,19 @@ function appendPose(pose){
 		sample_array.push(pose2D);
 	}
 
-	if(historypicker.value > 0){
-		while (sample_array.length > historypicker.value) {
-			sample_array.shift();
+	while (sample_array.length > historypicker.value) {
+		sample_array.shift();
+	}
+
+	const now = Date.now();
+	if(now - time_since_updated > 3000){
+		updateTextDisplay();
+
+		if(save_history.checked){
+			savePoints();
 		}
+
+		time_since_updated = now;
 	}
 
 	return true;
@@ -248,8 +330,9 @@ function connect(){
 			return;
 		}
 
-		const transformed = tf.transformPoseStamped(
-			msg.header,
+		const transformed = tf.transformPose(
+			msg.header.frame_id,
+			tf.fixed_frame, 
 			msg.pose.pose.position, 
 			msg.pose.pose.orientation
 		)
@@ -310,6 +393,7 @@ selectionbox.addEventListener("click", (event) => {
 
 click_icon.addEventListener("click", (event) => {
 	loadTopics();
+	updateTextDisplay();
 });
 
 loadTopics();
@@ -366,4 +450,3 @@ window.addEventListener('orientationchange', resizeScreen);
 resizeScreen();
 
 console.log("Odom Pose Tracker Widget Loaded {uniqueID}")
-

--- a/public/templates/odom/odom_script.js
+++ b/public/templates/odom/odom_script.js
@@ -65,8 +65,10 @@ const historypicker = document.getElementById('{uniqueID}_history');
 historypicker.addEventListener("input", (event) =>{
 	saveSettings();
 
-	while (sample_array.length > historypicker.value) {
-		sample_array.shift();
+	if(historypicker.value > 0){
+		while (sample_array.length > historypicker.value) {
+			sample_array.shift();
+		}
 	}
 
 	drawHistory();
@@ -196,8 +198,10 @@ function appendPose(pose){
 		sample_array.push(pose2D);
 	}
 
-	while (sample_array.length > historypicker.value) {
-		sample_array.shift();
+	if(historypicker.value > 0){
+		while (sample_array.length > historypicker.value) {
+			sample_array.shift();
+		}
 	}
 
 	return true;

--- a/public/templates/odom/odom_script.js
+++ b/public/templates/odom/odom_script.js
@@ -93,6 +93,40 @@ clearHistoryButton.addEventListener('click', ()=>{
 	db.setObject(DB_KEY, null);
 });
 
+const downloadCSVButton = document.getElementById("{uniqueID}_downloadcsv");
+
+downloadCSVButton.addEventListener('click', () => {
+
+	if(sample_array.length === 0){
+		alert("No poses to export.");
+		return;
+	}
+
+	let csv = "x,y,yaw\n";
+
+	for(const pose of sample_array){
+		csv += `${pose.x},${pose.y},${pose.yaw}\n`;
+	}
+
+	const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+
+	const url = URL.createObjectURL(blob);
+
+	const link = document.createElement('a');
+	link.href = url;
+
+	const safeTopic = raw_target.replace(/[^\w\d_-]/g, "_");
+	link.download = `${safeTopic || "odom_history"}.csv`;
+
+	document.body.appendChild(link);
+	link.click();
+	document.body.removeChild(link);
+
+	URL.revokeObjectURL(url);
+
+	status.setOK("CSV downloaded.");
+});
+
 //Settings
 if(settings.hasOwnProperty("{uniqueID}")){
 	const loaded_data = settings["{uniqueID}"];

--- a/public/templates/odom/odom_script.js
+++ b/public/templates/odom/odom_script.js
@@ -244,9 +244,8 @@ function connect(){
 			return;
 		}
 
-		const transformed = tf.transformPose(
-			msg.header.frame_id,
-			tf.fixed_frame, 
+		const transformed = tf.transformPoseStamped(
+			msg.header,
 			msg.pose.pose.position, 
 			msg.pose.pose.orientation
 		)

--- a/public/templates/odom/odom_script.js
+++ b/public/templates/odom/odom_script.js
@@ -79,7 +79,7 @@ const historypicker = document.getElementById('{uniqueID}_history');
 historypicker.addEventListener("input", (event) =>{
 	saveSettings();
 
-	while (sample_array.length > historypicker.value) {
+	while (sample_array.length > parseInt(historypicker.value)) {
 		sample_array.shift();
 	}
 
@@ -89,13 +89,25 @@ historypicker.addEventListener("input", (event) =>{
 const clearHistoryButton = document.getElementById("{uniqueID}_clearhistory");
 clearHistoryButton.addEventListener('click', ()=>{
 	sample_array = [];
-	points_since_flush = 0;
 	db.setObject(DB_KEY, null);
+	updateTextDisplay();
+	drawHistory();
 });
 
 const downloadCSVButton = document.getElementById("{uniqueID}_downloadcsv");
 
 downloadCSVButton.addEventListener('click', () => {
+
+	function getCurrentDateTimeString() {
+		const date = new Date();
+		const year = date.getFullYear();
+		const month = (date.getMonth() + 1).toString().padStart(2, '0');
+		const day = date.getDate().toString().padStart(2, '0');
+		const hours = date.getHours().toString().padStart(2, '0');
+		const minutes = date.getMinutes().toString().padStart(2, '0');
+
+		return `${year}-${month}-${day}-${hours}-${minutes}`;
+	}
 
 	if(sample_array.length === 0){
 		alert("No poses to export.");
@@ -115,7 +127,7 @@ downloadCSVButton.addEventListener('click', () => {
 	const link = document.createElement('a');
 	link.href = url;
 
-	const safeTopic = raw_target.replace(/[^\w\d_-]/g, "_");
+	const safeTopic = `${raw_target}_in_${tf.fixed_frame}_`.replace(/[^\w\d_-]/g, "_")+getCurrentDateTimeString();
 	link.download = `${safeTopic || "odom_history"}.csv`;
 
 	document.body.appendChild(link);
@@ -223,7 +235,7 @@ async function drawHistory(){
 		view_points[i].yaw = sample_array[i].yaw;
 	}
 
-	//continious line 
+	//continuous line 
 	if(drawpath.checked){
 		ctx.moveTo(view_points[0].x, view_points[0].y);
 		for (let i = 1; i < view_points.length; i++) {
@@ -237,10 +249,10 @@ async function drawHistory(){
 	if(drawarrows.checked){
 		ctx.beginPath();
 
-		let prev_p = Infinity;
+		let prev_p = null;
 		for (let i = 0; i < view_points.length; i++) {
 			const p = view_points[i];
-			if(i == 0 || Math.hypot(p.x - prev_p.x, p.y - prev_p.y) > 20){
+			if(prev_p === null || Math.hypot(p.x - prev_p.x, p.y - prev_p.y) > 20){
 				ctx.setTransform(1,0,0,-1,p.x, p.y); //sx,0,0,sy,px,py
 				ctx.rotate(p.yaw);
 				drawArrow(15, 5);
@@ -293,7 +305,7 @@ function appendPose(pose){
 		yaw: pose.rotation.toEuler().h
 	};
 
-	if(sample_array.length > 2){
+	if(sample_array.length > 0){
 		const last = sample_array[sample_array.length-1];
 		const delta = Math.hypot(last.x - pose2D.x, last.y - pose2D.y);
 		if(delta > 0.03){
@@ -305,7 +317,7 @@ function appendPose(pose){
 		sample_array.push(pose2D);
 	}
 
-	while (sample_array.length > historypicker.value) {
+	while (sample_array.length > parseInt(historypicker.value)) {
 		sample_array.shift();
 	}
 

--- a/public/templates/path/path_modal.html
+++ b/public/templates/path/path_modal.html
@@ -9,10 +9,24 @@
 			<!-- add topics here-->
 		</select>
 
-		<div class="spacer"></div>
+		<p>Display a nav_msgs/Path.</p>
+
+		<div class="live_data_display">
+			<p id="{uniqueID}_frame_text">Frame: ?</p>
+			<p id="{uniqueID}_points_text">Points: ?</p>
+			<p id="{uniqueID}_distance_text">Distance: ?</p>
+		</div>
+
 
 		<label for="{uniqueID}_colorpicker">Colour:</label>
 		<input type="color" value="#54db67" id="{uniqueID}_colorpicker">
+
+		<div class="spacer"></div>
+		<div class="spacer"></div>
+
+		<label for="{uniqueID}_opacity">Opacity:</label>
+		<span id="{uniqueID}_opacity_value">1.0</span>
+		<input type="range" value="1.0" step="0.05" min="0.0" max="1.0" id="{uniqueID}_opacity">
 
 		<div class="spacer"></div>
 
@@ -20,8 +34,6 @@
 		<input type="number" value="100" step="1" min="0" max="10000" id="{uniqueID}_throttle">
 
 		<div class="spacer"></div>
-
-		<p>Display a nav_msgs/Path.</p>
 
 		<hr class="dark_hr"/>
 

--- a/public/templates/path/path_script.js
+++ b/public/templates/path/path_script.js
@@ -22,6 +22,10 @@ let path_topic = undefined;
 
 let pose_array = undefined;
 
+const text_frameid = document.getElementById("{uniqueID}_frame_text");
+const text_point_count = document.getElementById("{uniqueID}_points_text");
+const text_total_dist = document.getElementById("{uniqueID}_distance_text");
+
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const click_icon = document.getElementById("{uniqueID}_icon");
 const icon = click_icon.getElementsByTagName('object')[0];
@@ -42,11 +46,30 @@ throttle.addEventListener("input", (event) =>{
 	connect();
 });
 
+const opacitySlider = document.getElementById('{uniqueID}_opacity');
+const opacityValue = document.getElementById('{uniqueID}_opacity_value');
+
+function setOpacityText(val){
+	if(val == 0.0)
+		opacityValue.textContent = "0.0 (Path rendering disabled)";
+	else
+		opacityValue.textContent = val;
+}
+
+opacitySlider.addEventListener('input', () =>  {
+	setOpacityText(opacitySlider.value);
+	saveSettings();
+	drawPath();
+});
+
 
 //Settings
 if(settings.hasOwnProperty("{uniqueID}")){
 	const loaded_data  = settings["{uniqueID}"];
 	topic = loaded_data.topic;
+
+	opacitySlider.value = loaded_data.opacity ?? 1.0;
+	setOpacityText(loaded_data.opacity);
 
 	colourpicker.value = loaded_data.color ?? "#54db67";
 	throttle.value = loaded_data.throttle ?? 100;
@@ -66,9 +89,32 @@ function saveSettings(){
 	settings["{uniqueID}"] = {
 		topic: topic,
 		color: colourpicker.value,
-		throttle: throttle.value	
+		throttle: throttle.value,
+		opacity: opacitySlider.value
 	}
 	settings.save();
+}
+
+function getDistance(posearray) {
+    if (!Array.isArray(posearray) || posearray.length < 2)
+		return 0;
+    
+    let dist = 0;
+    for (let i = 0; i < posearray.length - 1; i++) {
+        const pose1 = posearray[i]?.pose?.position;
+        const pose2 = posearray[i + 1]?.pose?.position;
+        
+        // Skip this pair if either point is missing
+        if (!pose1 || !pose2) continue;
+        
+        const dx = pose2.x - pose1.x;
+        const dy = pose2.y - pose1.y;
+        const dz = pose2.z - pose1.z;
+        
+        dist += Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+    
+    return dist;
 }
 
 //Rendering
@@ -78,7 +124,9 @@ async function drawPath(){
     const hei = canvas.height;
 	ctx.clearRect(0, 0, wid, hei);
 
-	if(pose_array === undefined || pose_array.length < 2){
+	ctx.globalAlpha = opacitySlider.value;
+
+	if(pose_array === undefined || pose_array.length < 2 || opacitySlider.value == 0.0){
 		return false;
 	}
 
@@ -159,6 +207,21 @@ function connect(){
 				point.pose.orientation
 			));
 		});
+
+		text_frameid.innerText = "Frame: "+msg.header.frame_id;
+		text_point_count.innerText = "Points: "+msg.poses.length;
+
+		let dist = getDistance(msg.poses)
+
+		if(dist > 1000.0){
+			dist /= 1000.0
+			text_total_dist.innerText = "Distance: "+dist.toFixed(3)+" km";
+		}else if(dist < 1.0){
+			dist *= 100.0
+			text_total_dist.innerText = "Distance: "+dist.toFixed(1)+" cm";
+		}else{
+			text_total_dist.innerText = "Distance: "+dist.toFixed(2)+" m";
+		}
 
 		pose_array = newposes;
 		drawPath();

--- a/public/templates/path/path_script.js
+++ b/public/templates/path/path_script.js
@@ -143,18 +143,15 @@ function connect(){
 				point.header.frame_id = tf.fixed_frame;
 				error = true;
 			}
-
-			const frame = tf.absoluteTransforms[point.header.frame_id];
 	
-			if(!frame){
+			if(!tf.absoluteTransforms[point.header.frame_id]){
 				status.setError("Required transform frame \""+point.header.frame_id+"\" not found.");
 				error = true;
 				return;
 			}
 	
-			newposes.push(tf.transformPose(
-				point.header.frame_id, 
-				tf.fixed_frame, 
+			newposes.push(tf.transformPoseStamped(
+				point.header, 
 				point.pose.position, 
 				point.pose.orientation
 			));

--- a/public/templates/pointcloud/pointcloud_script.js
+++ b/public/templates/pointcloud/pointcloud_script.js
@@ -389,7 +389,7 @@ function connect(){
 					y: bytes_to_datatype(dataview, byteOffset + yData.offset, yData.datatype, littleEndian),
 					z: bytes_to_datatype(dataview, byteOffset + zData.offset, zData.datatype, littleEndian)
 				};
-				const transformed = tf.transformPoseStamped(msg.header.frame_id, point, new Quaternion()).translation;
+				const transformed = tf.transformPoseStamped(msg.header, point, new Quaternion()).translation;
 
 				if(rgbData){
 					const bits = dataview.getUint32(byteOffset + rgbData.offset, littleEndian);

--- a/public/templates/pointcloud/pointcloud_script.js
+++ b/public/templates/pointcloud/pointcloud_script.js
@@ -303,8 +303,7 @@ function connect(){
 			error = true;
 		}
 
-		const pose = tf.absoluteTransforms[msg.header.frame_id];
-		if(!pose){
+		if(!tf.absoluteTransforms[msg.header.frame_id]){
 			status.setError("Required transform frame \""+msg.header.frame_id+"\" not found.");
 			return;
 		}
@@ -366,7 +365,7 @@ function connect(){
 					y: bytes_to_datatype(dataview, byteOffset + yData.offset, yData.datatype, littleEndian),
 					z: bytes_to_datatype(dataview, byteOffset + zData.offset, zData.datatype, littleEndian)
 				};
-				const transformed = tf.transformPose(msg.header.frame_id, tf.fixed_frame, point, new Quaternion()).translation;
+				const transformed = tf.transformPoseStamped(msg.header, point, new Quaternion()).translation;
 				pointarray.push(transformed);
 			}
 
@@ -390,7 +389,7 @@ function connect(){
 					y: bytes_to_datatype(dataview, byteOffset + yData.offset, yData.datatype, littleEndian),
 					z: bytes_to_datatype(dataview, byteOffset + zData.offset, zData.datatype, littleEndian)
 				};
-				const transformed = tf.transformPose(msg.header.frame_id, tf.fixed_frame, point, new Quaternion()).translation;
+				const transformed = tf.transformPoseStamped(msg.header.frame_id, point, new Quaternion()).translation;
 
 				if(rgbData){
 					const bits = dataview.getUint32(byteOffset + rgbData.offset, littleEndian);

--- a/public/templates/posearray/posearray_script.js
+++ b/public/templates/posearray/posearray_script.js
@@ -197,9 +197,8 @@ function connect(){
 		frame = tf.fixed_frame;
 
 		msg.poses.forEach(p => {
-			const transformed = tf.transformPose(
-				msg.header.frame_id, 
-				tf.fixed_frame, 
+			const transformed = tf.transformPoseStamped(
+				msg.header,
 				p.position, 
 				p.orientation
 			);

--- a/public/templates/posewithcovariancestamped/posewithcovariancestamped_script.js
+++ b/public/templates/posewithcovariancestamped/posewithcovariancestamped_script.js
@@ -372,9 +372,8 @@ function connect(){
 			q = new Quaternion();
 		}
 
-		const transformed = tf.transformPose(
-			msg.header.frame_id, 
-			tf.fixed_frame, 
+		const transformed = tf.transformPoseStamped(
+			msg.header,
 			pose.position, 
 			q
 		);

--- a/public/templates/range/range_script.js
+++ b/public/templates/range/range_script.js
@@ -213,7 +213,7 @@ function connect(){
 			error = true;
 		}
 
-		const pose = tf.absoluteTransforms[msg.header.frame_id];
+		const pose = tf.getAbsoluteTransform(msg.header);
 
 		if(!pose){
 			status.setError("Required transform frame \""+msg.header.frame_id+"\" not found.");

--- a/public/templates/satelite/satelite_modal.html
+++ b/public/templates/satelite/satelite_modal.html
@@ -1,6 +1,6 @@
 <div id="{uniqueID}_modal" class="modal_outer noselect">
 	<div class="modal_inner noselect">
-		<h3>Satelite Tiles</h3>
+		<h3>Satellite Tiles</h3>
 		<p id="{uniqueID}_status" class="status">Status: Ok.</p>
 		<hr class="dark_hr"/>
 
@@ -35,14 +35,14 @@
 		</datalist> 
 
 
-		<p class="comment">The tile server can be changed to anything that uses 265x256 sized tiles, the Web Mercator projection, and follows the same {x},{y},{z} convention. </p>
+		<p class="comment">The tile server can be changed to anything that uses 256x256 sized tiles, the Web Mercator projection, and follows the same {x},{y},{z} convention. </p>
 
 		<div class="spacer"></div>
 
 		<label>Texture smoothing:</label>
 		<input type="checkbox" checked id="{uniqueID}_smoothing">
 
-		<p class="comment">Max tile zoom doesn't provide much detail up close, so you get to chose between pixelated or blurry.</p>
+		<p class="comment">Max tile zoom doesn't provide much detail up close, so you get to choose between pixelated or blurry.</p>
 
 		<div class="spacer"></div>
 

--- a/public/templates/satelite/satelite_script.js
+++ b/public/templates/satelite/satelite_script.js
@@ -165,12 +165,11 @@ function drawTile(screenSize, i, j, tempMeterSize, tempZoomLevel, maxtile) {
 		if (!parentCrop)
 			tileImage = placeholder;
 	}
-
 	let transformed;
 	if (!ignoreRotationCheckbox.checked) {
-		transformed = tf.transformPose(map_fix.header.frame_id, tf.fixed_frame, {x: -offsetX, y: offsetY, z: 0}, new Quaternion());
+		transformed = tf.transformPoseStamped(map_fix.header, {x: -offsetX, y: offsetY, z: 0}, new Quaternion());
 	} else {
-		transformed = tf.transformPose(map_fix.header.frame_id, tf.fixed_frame, {x: 0, y: 0, z: 0}, new Quaternion());
+		transformed = tf.transformPoseStamped(map_fix.header, {x: 0, y: 0, z: 0}, new Quaternion());
 		transformed.translation.x -= offsetX;
 		transformed.translation.y += offsetY;
 		transformed.rotation = new Quaternion();
@@ -213,7 +212,7 @@ async function drawTiles(){
 		return;
 	}
 
-	const frame = tf.absoluteTransforms[map_fix.header.frame_id];
+	const frame = tf.getAbsoluteTransform(map_fix.header);
 
 	let	tempZoomLevel = Math.round(Math.log2(view.scale)+17);
 	tempZoomLevel = clamp(tempZoomLevel, 7, 19);
@@ -243,8 +242,8 @@ async function drawTiles(){
 			if(ignoreRotationCheckbox.checked){
 				transformed = {
 					translation: {
-						x: -tf.absoluteTransforms[map_fix.header.frame_id].translation.x + meters.x,
-						y: -tf.absoluteTransforms[map_fix.header.frame_id].translation.y + meters.y
+						x: -frame.translation.x + meters.x,
+						y: -frame.translation.y + meters.y
 					}
 				}
 			}else{

--- a/public/templates/satelite/satelite_script.js
+++ b/public/templates/satelite/satelite_script.js
@@ -85,6 +85,17 @@ tileServerString.addEventListener('blur', function () {
     }
 });
 
+let drawPending = false;
+function scheduleDraw() {
+    if (!drawPending) {
+        drawPending = true;
+        requestAnimationFrame(() => {
+            drawPending = false;
+            drawTiles();
+        });
+    }
+}
+
 const canvas = document.getElementById('{uniqueID}_canvas');
 const ctx = canvas.getContext('2d', { colorSpace: 'srgb' });
 ctx.clip = function(){};
@@ -121,53 +132,58 @@ function saveSettings(){
 	settings.save();
 }
 
-function drawTile(screenSize, i, j, tempMeterSize, tempZoomLevel, maxtile){
+function findParentTile(x, y, z, maxLevelsUp = 4) {
+	for (let dz = 1; dz <= maxLevelsUp && (z - dz) >= 0; dz++) {
+		const parentX = x >> dz;
+		const parentY = y >> dz;
+		const parentURL = server_url.replace("{z}", z - dz).replace("{x}", parentX).replace("{y}", parentY);
+		const parentImage = navsat.live_cache[parentURL];
+		if (parentImage && parentImage.complete) {
+			const regionSize = navsat.tile_size >> dz; // size of our tile's region within the parent
+			const srcX = (x % (1 << dz)) * regionSize;
+			const srcY = (y % (1 << dz)) * regionSize;
+			return { image: parentImage, srcX, srcY, srcSize: regionSize };
+		}
+	}
+	return null;
+}
 
-	//wrap around the date line
+function drawTile(screenSize, i, j, tempMeterSize, tempZoomLevel, maxtile) {
 	const x = (fix_data.tilePos.x + i + maxtile + 1) % (maxtile + 1);
 	const y = (fix_data.tilePos.y + j + maxtile + 1) % (maxtile + 1);
 
 	const offsetX = fix_data.offset.x - i * tempMeterSize;
 	const offsetY = fix_data.offset.y - j * tempMeterSize;
 
-	const tileURL = server_url.replace("{z}",tempZoomLevel).replace("{x}",x).replace("{y}",y);
+	const tileURL = server_url.replace("{z}", tempZoomLevel).replace("{x}", x).replace("{y}", y);
 	let tileImage = navsat.live_cache[tileURL];
+	let parentCrop = null;
 
-	if(!tileImage || !tileImage.complete){
-		tileImage = placeholder;
+	if (!tileImage || !tileImage.complete) {
 		navsat.enqueue(tileURL);
+		parentCrop = findParentTile(x, y, tempZoomLevel);
+		if (!parentCrop)
+			tileImage = placeholder;
 	}
 
-	let transformed = undefined;
-
-	if(!ignoreRotationCheckbox.checked){
-		transformed = tf.transformPose(
-			map_fix.header.frame_id,
-			tf.fixed_frame,
-			{x: -offsetX, y: offsetY, z: 0},
-			new Quaternion()
-		);
-	}else{
-		transformed = tf.transformPose(
-			map_fix.header.frame_id,
-			tf.fixed_frame,
-			{x: 0, y: 0, z: 0},
-			new Quaternion()
-		);
-
+	let transformed;
+	if (!ignoreRotationCheckbox.checked) {
+		transformed = tf.transformPose(map_fix.header.frame_id, tf.fixed_frame, {x: -offsetX, y: offsetY, z: 0}, new Quaternion());
+	} else {
+		transformed = tf.transformPose(map_fix.header.frame_id, tf.fixed_frame, {x: 0, y: 0, z: 0}, new Quaternion());
 		transformed.translation.x -= offsetX;
 		transformed.translation.y += offsetY;
-		transformed.rotation = Quaternion()
+		transformed.rotation = new Quaternion();
 	}
 
-	const pos = view.fixedToScreen({
-		x: transformed.translation.x,
-		y: transformed.translation.y,
-	});
-
+	const pos = view.fixedToScreen({x: transformed.translation.x, y: transformed.translation.y});
 	const matrix = view.quaterionToProjectionMatrix(transformed.rotation);
 	ctx.setTransform(matrix[0], matrix[1], matrix[2], matrix[3], pos.x, pos.y);
-	ctx.drawImage(tileImage, 0, 0, screenSize, screenSize);
+
+	if (parentCrop)
+		ctx.drawImage(parentCrop.image, parentCrop.srcX, parentCrop.srcY, parentCrop.srcSize, parentCrop.srcSize, 0, 0, screenSize, screenSize);
+	else
+		ctx.drawImage(tileImage, 0, 0, screenSize, screenSize);
 }
 
 function clamp(val, from, to){
@@ -420,18 +436,18 @@ loadTopics();
 function resizeScreen(){
 	canvas.height = window.innerHeight;
 	canvas.width = window.innerWidth;
-	drawTiles();
+	scheduleDraw();
 }
 
-window.addEventListener("navsat_tilecache_updated", drawTiles);
-window.addEventListener("tf_fixed_frame_changed", drawTiles);
+window.addEventListener("navsat_tilecache_updated", scheduleDraw);
+window.addEventListener("tf_fixed_frame_changed", scheduleDraw);
 window.addEventListener("tf_changed", ()=>{
 	if(map_fix && map_fix.header.frame_id != tf.fixed_frame){
-		drawTiles();
+		scheduleDraw();
 	}
 });
 
-window.addEventListener("view_changed", drawTiles);
+window.addEventListener("view_changed", scheduleDraw);
 window.addEventListener('resize', resizeScreen);
 window.addEventListener('orientationchange', resizeScreen);
 

--- a/public/templates/satelite/satelite_script.js
+++ b/public/templates/satelite/satelite_script.js
@@ -180,8 +180,11 @@ function drawTile(screenSize, i, j, tempMeterSize, tempZoomLevel, maxtile) {
 	const matrix = view.quaterionToProjectionMatrix(transformed.rotation);
 	ctx.setTransform(matrix[0], matrix[1], matrix[2], matrix[3], pos.x, pos.y);
 
-	if (parentCrop)
+	if (parentCrop){
+		ctx.globalAlpha = opacitySlider.value * 0.8;
 		ctx.drawImage(parentCrop.image, parentCrop.srcX, parentCrop.srcY, parentCrop.srcSize, parentCrop.srcSize, 0, 0, screenSize, screenSize);
+		ctx.globalAlpha = opacitySlider.value;
+	}
 	else
 		ctx.drawImage(tileImage, 0, 0, screenSize, screenSize);
 }

--- a/public/templates/scan/scan_script.js
+++ b/public/templates/scan/scan_script.js
@@ -203,8 +203,8 @@ function connect(){
 			error = true;
 		}
 
-		const pose = tf.absoluteTransforms[msg.header.frame_id];
-
+		let pose = tf.getAbsoluteTransform(msg.header);
+		
 		if(!pose){
 			status.setError("Required transform frame \""+msg.header.frame_id+"\" not found.");
 			return;

--- a/public/templates/waypoints/waypoints_modal.html
+++ b/public/templates/waypoints/waypoints_modal.html
@@ -41,10 +41,8 @@
 			<li><button id="{uniqueID}_z_set" >Set all Z values</button></li>
 		</ul>
 		
-		
-		<p style="color: #b4b4b4;">When editing X/Y/Z positions, click the icon again to stop editing.</p>
-		
-		<div class="spacer"></div>
+		<p class="comment">When editing X/Y/Z positions, click the icon again to stop editing.</p>
+
 
 		<label for="{uniqueID}_margin">Safety margin visual indicator (meters):</label>
 		<input type="number" value="0.8" step="0.1" min="0" max="1000" id="{uniqueID}_margin">
@@ -54,7 +52,12 @@
 		<label>Start from closest waypoint:</label>
 		<input type="checkbox" id="{uniqueID}_startclosest">
 
-		<div class="spacer"></div>
+		<h4>Import Path</h4>
+
+		<button id="{uniqueID}_importcsv">Load CSV</button>
+		<input type="file" id="{uniqueID}_importcsv_input" accept=".csv" style="display:none;">
+
+		<p class="comment">Imports x,y,z column data assumed to be in the fixed frame, such as paths recorded by the Pose Tracker widget. Z is optional.</p>
 
 		<h4>Clear Path</h4>
 

--- a/public/templates/waypoints/waypoints_script.js
+++ b/public/templates/waypoints/waypoints_script.js
@@ -65,6 +65,85 @@ startCheckbox.addEventListener('change', ()=>{
 	saveSettings();
 });
 
+const importCSVButton = document.getElementById("{uniqueID}_importcsv");
+const importCSVInput = document.getElementById("{uniqueID}_importcsv_input");
+
+importCSVButton.addEventListener('click', ()=>{
+	importCSVInput.click();
+});
+
+importCSVInput.addEventListener('change', async (event)=>{
+
+	const file = event.target.files[0];
+	if(!file){
+		return;
+	}
+
+	try{
+		const text = await file.text();
+		const lines = text.split(/\r?\n/).map(line => line.trim()).filter(line => line.length > 0);
+
+		if(lines.length < 2){
+			status.setError("CSV file is empty.");
+			return;
+		}
+
+		const headers = lines[0].split(",").map(h => h.trim().toLowerCase());
+		const xIndex = headers.findIndex(h => h === "x");
+		const yIndex = headers.findIndex(h => h === "y");
+		const zIndex = headers.findIndex(h => h === "z");
+
+		if(xIndex < 0 || yIndex < 0){
+			status.setError("CSV must contain X and Y columns.");
+			return;
+		}
+
+		const imported_points = [];
+
+		for(let i = 1; i < lines.length; i++){
+
+			const cols = lines[i].split(",").map(c => c.trim());
+			const x = parseFloat(cols[xIndex]);
+			const y = parseFloat(cols[yIndex]);
+
+			let z = 0;
+			if(zIndex >= 0){
+				z = parseFloat(cols[zIndex]);
+				if(Number.isNaN(z)){
+					z = 0;
+				}
+			}
+
+			if(Number.isNaN(x) || Number.isNaN(y)){
+				continue;
+			}
+
+			imported_points.push({
+				x: x,
+				y: y,
+				z: z
+			});
+		}
+
+		if(imported_points.length === 0){
+			status.setError("No valid points found in CSV.");
+			return;
+		}
+
+		points = imported_points;
+
+		drawWaypoints();
+		saveSettings();
+		status.setOK(`Imported ${points.length} waypoints.`);
+
+	}catch(error){
+		console.error(error);
+		status.setError("Failed to import CSV.");
+	}
+
+	importCSVInput.value = "";
+});
+
 // Settings
 
 if(settings.hasOwnProperty("{uniqueID}")){


### PR DESCRIPTION
## Satelite tile fetching improvements

- event based fetching, as fast as the browser allows
- if there's no smaller tile yet, a layer above will be mapped into 4 smaller sections, which prevents an instant wall of loading placeholder textures when zooming in quickly, these have slightly lower opacity so it's possible to more easily tell when the current zoom level has fully loaded
- removed infinite retry hangs which were causing downloading queues to stay full, tiles get re-tried when they're once again on screen

## Pose tracker persistence:

So the pose tracker now saves the tracked path to indexeddb, shows some statistics, and can export it to CSV:

<img width="1789" height="1001" alt="image" src="https://github.com/user-attachments/assets/a17dca92-07a6-40b7-8b69-6f9e37cec1b8" />

<img width="1239" height="811" alt="image" src="https://github.com/user-attachments/assets/2335f15b-6140-4ee3-8bbd-028109823fa5" />

That export can also be loaded by the waypoint mission widget, which should make it possible to recreate a robot's driven path and ingest arbitrary generated paths:

<img width="1783" height="1182" alt="image" src="https://github.com/user-attachments/assets/628e30a2-a80b-4483-90c8-e839acda48b4" />

<img width="1471" height="965" alt="image" src="https://github.com/user-attachments/assets/d436f7de-fefd-4bd3-ad6d-27a7f6f0e5fa" />



## Other fixes

- a TF header matching is now used to better align messages to the fixed frame
- altimeter no longer autopublishes its target Float32 topic, it's set to disabled by default and doesn't clutter topic selection
- Path has some extra message statistics
- Pose Tracker now takes negative queue length, treats it as infinite (mostly closes #183)



