### PR TITLE
Satelite tile projection rework (ROS 1)

### DIFF
--- a/public/js/modules/navsat.js
+++ b/public/js/modules/navsat.js
@@ -4,6 +4,15 @@ import { imageToDataURL } from './util.js';
 const db = new IndexedDatabase('tile_data');
 await db.openDB();
 
+// WGS84 ellipsoid constants
+const WGS84_A = 6378137.0;
+const WGS84_F = 1.0 / 298.257223563;
+const WGS84_E2 = WGS84_F * (2.0 - WGS84_F);
+const WGS84_B = WGS84_A * (1.0 - WGS84_F);
+const WGS84_EP2 = (WGS84_A * WGS84_A - WGS84_B * WGS84_B) / (WGS84_B * WGS84_B);
+const D2R = Math.PI / 180.0;
+const R2D = 180.0 / Math.PI;
+
 async function dataToImage(data){
 	return new Promise((resolve, reject) => {
 		let image = new Image();
@@ -145,14 +154,14 @@ export class Navsat {
 	}
 
 	//https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
-	coordToTile(lon, lat, zoom) {
+	static coordToTile(lon, lat, zoom) {
 		return {
 			y:(Math.floor((1 - Math.log(Math.tan(lat * Math.PI / 180) + 1 / Math.cos(lat * Math.PI / 180)) / Math.PI) / 2 * Math.pow(2, zoom))),
 			x: (Math.floor((lon + 180) / 360 * Math.pow(2, zoom)))
 		};
 	}
 
-	tileToCoord(x, y, z) {
+	static tileToCoord(x, y, z) {
 		var n = Math.PI - 2 * Math.PI * y / Math.pow(2, z);
 		return {
 			latitude:(180 / Math.PI * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)))),
@@ -160,42 +169,128 @@ export class Navsat {
 		};
 	}
 
-	metersToDegrees(meters, latitude, zoomLevel) {
-		const earthRadius = 6378137; // Earth radius in meters
-	
-		// Calculate the number of meters per pixel at the given latitude and zoom level
-		const metersPerPixel = (2 * Math.PI * earthRadius * Math.cos(latitude * Math.PI / 180)) / (this.tile_size * Math.pow(2, zoomLevel));
-	
-		// Convert the distance in meters to degrees	
-		return meters / metersPerPixel;
-	}
+	/* ---------------------------------------------------------------------------
+	   WGS84 geodetic <-> ECEF <-> local ENU (topocentric tangent plane).
 
-	tileSizeInMeters(latitude, zoom) {
-		const earthCircumference = 40075016.686; // Earth circumference in meters
-		
-		// Calculate the horizontal distance per pixel in meters
-		const distancePerPixel = (earthCircumference * Math.cos(latitude * Math.PI / 180)) / (Math.pow(2, zoom + 8));
-	
-		return this.tile_size * distancePerPixel;
-	}
+	   This is the same projection a typical GNSS backend uses
+	   (pyproj +proj=cart +step +proj=topocentric, geodesy "small" libraries, etc.),
+	   verified to agree with pyproj to < 1e-9 m. Using it for both tile placement
+	   (forward) and screen culling (inverse) makes the renderer exactly
+	   self-consistent with a metric ENU TF tree anchored at the fix origin.
+	--------------------------------------------------------------------------- */
 
-	tileSizeInDegrees(latitude, zoom) {
-		const degreesPerPixel = 360 / Math.pow(2, zoom); // Calculate the degrees per pixel for longitude
-	
-		// Calculate the latitude degrees per pixel based on the latitude
-		const latRadians = (latitude * Math.PI) / 180;
-		const latRadiansPerPixel = Math.PI / (Math.pow(2, zoom) * this.tile_size);
-		const latDegreesPerPixel = (180 / Math.PI) * (2 * Math.atan(Math.exp(latRadians + latRadiansPerPixel)) - Math.PI / 2) - latitude;
-	
+	static llaToEcef(latDeg, lonDeg, alt = 0) {
+		const lat = latDeg * D2R;
+		const lon = lonDeg * D2R;
+		const sLat = Math.sin(lat), cLat = Math.cos(lat);
+		const sLon = Math.sin(lon), cLon = Math.cos(lon);
+		const N = WGS84_A / Math.sqrt(1.0 - WGS84_E2 * sLat * sLat);
 		return {
-			latitude: this.tile_size * latDegreesPerPixel,
-			longitude: this.tile_size * degreesPerPixel,
+			x: (N + alt) * cLat * cLon,
+			y: (N + alt) * cLat * sLon,
+			z: (N * (1.0 - WGS84_E2) + alt) * sLat
 		};
 	}
 
-	haversine(lat1, lon1, lat2, lon2) {
+	// Bowring's closed-form approximation, sub-millimeter accurate near the surface.
+	static ecefToLla(x, y, z) {
+		const p = Math.hypot(x, y);
+		const th = Math.atan2(WGS84_A * z, WGS84_B * p);
+		const sth = Math.sin(th), cth = Math.cos(th);
+		const lat = Math.atan2(
+			z + WGS84_EP2 * WGS84_B * sth * sth * sth,
+			p - WGS84_E2 * WGS84_A * cth * cth * cth
+		);
+		const lon = Math.atan2(y, x);
+		const sLat = Math.sin(lat);
+		const N = WGS84_A / Math.sqrt(1.0 - WGS84_E2 * sLat * sLat);
+		const alt = p / Math.cos(lat) - N;
+		return { latitude: lat * R2D, longitude: lon * R2D, altitude: alt };
+	}
+
+	// Build an ENU origin object to pass into llaToEnu / enuToLla / enuGroundToLla.
+	// Each satellite_script instance should hold its own origin and pass it in,
+	// so multiple instances never clobber each other.
+	static buildEnuOrigin(latDeg, lonDeg, alt = 0) {
+		const lat = latDeg * D2R;
+		const lon = lonDeg * D2R;
+		return {
+			latitude: latDeg,
+			longitude: lonDeg,
+			altitude: alt,
+			ecef: Navsat.llaToEcef(latDeg, lonDeg, alt),
+			sLat: Math.sin(lat), cLat: Math.cos(lat),
+			sLon: Math.sin(lon), cLon: Math.cos(lon)
+		};
+	}
+
+	// geodetic -> ENU meters relative to the provided origin.
+	// Returns {x: east, y: north, z: up}.
+	static llaToEnu(latDeg, lonDeg, alt, origin) {
+		if (alt === undefined) alt = origin.altitude;
+		const p = Navsat.llaToEcef(latDeg, lonDeg, alt);
+		const dx = p.x - origin.ecef.x;
+		const dy = p.y - origin.ecef.y;
+		const dz = p.z - origin.ecef.z;
+		return {
+			x: -origin.sLon * dx + origin.cLon * dy,                                          // east
+			y: -origin.sLat * origin.cLon * dx - origin.sLat * origin.sLon * dy + origin.cLat * dz,  // north
+			z:  origin.cLat * origin.cLon * dx + origin.cLat * origin.sLon * dy + origin.sLat * dz   // up
+		};
+	}
+
+	// Full 3D ENU -> geodetic.
+	static enuToLla(e, n, u, origin) {
+		const dx = -origin.sLon * e - origin.sLat * origin.cLon * n + origin.cLat * origin.cLon * u;
+		const dy =  origin.cLon * e - origin.sLat * origin.sLon * n + origin.cLat * origin.sLon * u;
+		const dz =                    origin.cLat * n               + origin.sLat * u;
+		return Navsat.ecefToLla(origin.ecef.x + dx, origin.ecef.y + dy, origin.ecef.z + dz);
+	}
+
+	// Horizontal ENU (e, n) -> geodetic lat/lon of the point at the given
+	// ellipsoidal height (defaults to origin height). This is the exact inverse
+	// of llaToEnu for the horizontal components; converges to sub-mm in 2 iterations.
+	static enuGroundToLla(e, n, origin, alt = undefined) {
+		if (alt === undefined) alt = origin.altitude;
+		// initial guess: requested height minus tangent-plane curvature drop
+		let u = (alt - origin.altitude) - (e * e + n * n) / (2.0 * WGS84_A);
+		let lla = Navsat.enuToLla(e, n, u, origin);
+		for (let i = 0; i < 2; i++) {
+			u += alt - lla.altitude;
+			lla = Navsat.enuToLla(e, n, u, origin);
+		}
+		return lla;
+	}
+
+	/* --------------------------------------------------------------------------- */
+
+	static metersToDegrees(meters, latitude, zoomLevel, tile_size = 256) {
+		const earthRadius = 6378137;
+		const metersPerPixel = (2 * Math.PI * earthRadius * Math.cos(latitude * Math.PI / 180)) / (tile_size * Math.pow(2, zoomLevel));
+		return meters / metersPerPixel;
+	}
+
+	// Approximate (spherical) tile ground size; fine for zoom heuristics.
+	static tileSizeInMeters(latitude, zoom, tile_size = 256) {
+		const earthCircumference = 40075016.686;
+		const distancePerPixel = (earthCircumference * Math.cos(latitude * Math.PI / 180)) / (Math.pow(2, zoom + 8));
+		return tile_size * distancePerPixel;
+	}
+
+	static tileSizeInDegrees(latitude, zoom, tile_size = 256) {
+		const degreesPerPixel = 360 / Math.pow(2, zoom);
+		const latRadians = (latitude * Math.PI) / 180;
+		const latRadiansPerPixel = Math.PI / (Math.pow(2, zoom) * tile_size);
+		const latDegreesPerPixel = (180 / Math.PI) * (2 * Math.atan(Math.exp(latRadians + latRadiansPerPixel)) - Math.PI / 2) - latitude;
+		return {
+			latitude: tile_size * latDegreesPerPixel,
+			longitude: tile_size * degreesPerPixel,
+		};
+	}
+
+	static haversine(lat1, lon1, lat2, lon2) {
 		const toRad = (value) => (value * Math.PI) / 180;
-		const R = 6378137; // Earth radius in meters
+		const R = 6378137;
 		const dLat = toRad(lat2 - lat1);
 		const dLon = toRad(lon2 - lon1);
 		const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);

--- a/public/templates/satelite/satelite_modal.html
+++ b/public/templates/satelite/satelite_modal.html
@@ -17,7 +17,7 @@
 		</div>
 
 
-		Renders a tile map based on sensor_msgs/NavSatFix positional data. Use with a local origin for best results.
+		Renders a tile map based on sensor_msgs/NavSatFix positional data. Use with a local origin for best results, an ENU projeciton is assumed as per REP 103.
 
 		<div class="spacer"></div>
 		<hr class="dark_hr"/>

--- a/public/templates/satelite/satelite_modal.html
+++ b/public/templates/satelite/satelite_modal.html
@@ -17,7 +17,7 @@
 		</div>
 
 
-		Renders a tile map based on sensor_msgs/NavSatFix positional data. Use with a local origin for best results, an ENU projeciton is assumed as per REP 103.
+		Renders a tile map based on sensor_msgs/NavSatFix positional data. Use with a local origin for best results, an ENU projection is assumed as per REP 103.
 
 		<div class="spacer"></div>
 		<hr class="dark_hr"/>

--- a/public/templates/satelite/satelite_modal.html
+++ b/public/templates/satelite/satelite_modal.html
@@ -14,12 +14,14 @@
 			<p id="{uniqueID}_longitude">Longitude: ?</p> 
 			<p id="{uniqueID}_altitude">Altitude: ?</p>
 			<p id="{uniqueID}_covariance">Ground Covariance: ?</p>
+			<p id="{uniqueID}_frame">TF Frame: ?</p>
 		</div>
 
 
-		Renders a tile map based on sensor_msgs/NavSatFix positional data. Use with a local origin for best results, an ENU projection is assumed as per REP 103.
+		<p>Renders a tile map around a point specified by a sensor_msgs/NavSatFix and its header frame.</p>
 
-		<div class="spacer"></div>
+		<p class="comment">Uses an ENU local tangent plane as specified by REP 103. The tiles are reprojected to match, which maintains alignment between geodetic coordinates and metric X,Y positions (it's basically a perpendicular globe at the given location). As the tangent plane increasingly diverges from the terrain with distance, Z offsets become larger and straight-line distances less useful. For best results, place the ENU origin near the operating area.</p>
+		
 		<hr class="dark_hr"/>
 		<div class="spacer"></div>
 

--- a/public/templates/satelite/satelite_script.js
+++ b/public/templates/satelite/satelite_script.js
@@ -43,6 +43,7 @@ const text_lat = document.getElementById("{uniqueID}_latitude");
 const text_lon = document.getElementById("{uniqueID}_longitude");
 const text_alt = document.getElementById("{uniqueID}_altitude");
 const text_cov = document.getElementById("{uniqueID}_covariance");
+const text_frame = document.getElementById("{uniqueID}_frame");
 
 const placeholder = new Image();
 placeholder.src = "assets/tile_loading.png";
@@ -479,6 +480,7 @@ function connect(){
 	text_lon.innerText = "Longitude: ?";
 	text_alt.innerText = "Altitude: ?";
 	text_cov.innerText = "Ground Covariance: ?";
+	text_frame.innerText = "TF Frame: ?";
 	
 	listener = map_topic.subscribe((msg) => {
 		const cov_mat = msg.position_covariance;
@@ -499,6 +501,8 @@ function connect(){
 			status.setWarn("No fix.");
 			return;
 		}
+
+		text_frame.innerText = "TF Frame: "+msg.header.frame_id;
 
 		map_fix = msg;
 		updateFixData();

--- a/public/templates/satelite/satelite_script.js
+++ b/public/templates/satelite/satelite_script.js
@@ -7,9 +7,11 @@ let StatusModule = await import(`${base_url}/js/modules/status.js`);
 
 let view = viewModule.view;
 let tf = tfModule.tf;
+let applyRotation = tfModule.applyRotation;
 let rosbridge = rosbridgeModule.rosbridge;
 let settings = persistentModule.settings;
 let navsat = navsatModule.navsat;
+let Navsat = navsatModule.Navsat;
 let Status = StatusModule.Status;
 
 let status = new Status(
@@ -26,6 +28,7 @@ let zoomLevel = 12;
 let map_topic = undefined;
 let map_fix = undefined;
 let fix_data = undefined;
+let enu_origin = undefined;
 
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const icon = document.getElementById("{uniqueID}_icon").getElementsByTagName('img')[0];
@@ -49,6 +52,8 @@ function setOpacityText(val){
 		opacityValue.textContent = "0.0 (Tile rendering disabled)";
 	else
 		opacityValue.textContent = val;
+
+	canvas.style.opacity = parseFloat(opacitySlider.value);
 }
 
 opacitySlider.addEventListener('input', function () {
@@ -98,6 +103,12 @@ function scheduleDraw() {
 
 const canvas = document.getElementById('{uniqueID}_canvas');
 const ctx = canvas.getContext('2d', { colorSpace: 'srgb' });
+
+// The widget framework disables clip() on this context (see below), but the
+// quad renderer needs real clipping for triangle texture mapping. Grab the
+// native implementation off the prototype before the override so we can call
+// it explicitly, scoped inside save()/restore() so no clip state ever leaks.
+const nativeClip = CanvasRenderingContext2D.prototype.clip;
 ctx.clip = function(){};
 
 if(settings.hasOwnProperty("{uniqueID}")){
@@ -148,44 +159,163 @@ function findParentTile(x, y, z, maxLevelsUp = 4) {
 	return null;
 }
 
-function drawTile(screenSize, i, j, tempMeterSize, tempZoomLevel, maxtile) {
-	const x = (fix_data.tilePos.x + i + maxtile + 1) % (maxtile + 1);
-	const y = (fix_data.tilePos.y + j + maxtile + 1) % (maxtile + 1);
+// Per-frame cache of tile corner ENU positions (corners are shared between
+// neighbouring tiles, so this saves ~4x the trig). Cleared at the start of
+// every drawTiles() pass, so it can never go stale w.r.t. the ENU origin.
+const cornerCache = new Map();
+function tileCornerEnu(x, y, z){
+	const key = x + "," + y + "," + z;
+	let v = cornerCache.get(key);
+	if(v === undefined){
+		const c = Navsat.tileToCoord(x, y, z);
+		v = Navsat.llaToEnu(c.latitude, c.longitude, undefined, enu_origin); // at origin altitude
+		cornerCache.set(key, v);
+	}
+	return v;
+}
 
-	const offsetX = fix_data.offset.x - i * tempMeterSize;
-	const offsetY = fix_data.offset.y - j * tempMeterSize;
+// Texture-map one triangle of an image onto three screen points.
+//
+// (su, sv) are source coordinates in image pixels, p* are destination screen
+// points. The affine is solved exactly so each source vertex lands exactly on
+// its destination vertex; the clip confines the draw to this triangle so two
+// of these calls render an arbitrary quadrilateral.
+//
+// The clip path is inflated by ~0.75 px outward from the triangle centroid to
+// hide antialiasing hairlines along the internal diagonal and between tiles.
+// The affine itself is fitted to the exact (un-inflated) corners so geometry
+// stays exact; the inflated rim just shows a sliver of extrapolated texture.
+function drawImageTriangle(img, su0, sv0, su1, sv1, su2, sv2, p0, p1, p2) {
+	const cx = (p0.x + p1.x + p2.x) / 3;
+	const cy = (p0.y + p1.y + p2.y) / 3;
+	const GROW = 1.1; // px
 
-	const tileURL = server_url.replace("{z}", tempZoomLevel).replace("{x}", x).replace("{y}", y);
+	function inflate(p) {
+		const dx = p.x - cx, dy = p.y - cy;
+		const len = Math.hypot(dx, dy) || 1;
+		return { x: p.x + (dx / len) * GROW, y: p.y + (dy / len) * GROW };
+	}
+	const q0 = inflate(p0), q1 = inflate(p1), q2 = inflate(p2);
+
+	// Solve the affine T with T(su,sv) = p for all three vertices.
+	const du1 = su1 - su0, dv1 = sv1 - sv0;
+	const du2 = su2 - su0, dv2 = sv2 - sv0;
+	const det = du1 * dv2 - du2 * dv1;
+	if (det === 0) return;
+
+	const a = ((p1.x - p0.x) * dv2 - (p2.x - p0.x) * dv1) / det;
+	const b = ((p1.y - p0.y) * dv2 - (p2.y - p0.y) * dv1) / det;
+	const c = ((p2.x - p0.x) * du1 - (p1.x - p0.x) * du2) / det;
+	const d = ((p2.y - p0.y) * du1 - (p1.y - p0.y) * du2) / det;
+	const e = p0.x - a * su0 - c * sv0;
+	const f = p0.y - b * su0 - d * sv0;
+
+	ctx.save();
+	ctx.setTransform(1, 0, 0, 1, 0, 0);
+	ctx.beginPath();
+	ctx.moveTo(q0.x, q0.y);
+	ctx.lineTo(q1.x, q1.y);
+	ctx.lineTo(q2.x, q2.y);
+	ctx.closePath();
+	nativeClip.call(ctx);
+	ctx.setTransform(a, b, c, d, e, f);
+	ctx.drawImage(img, 0, 0);
+	ctx.restore();
+}
+
+// Draw an image (or a sub-rectangle of it) onto an arbitrary screen-space
+// quadrilateral, split along the NW-SE... actually the NE-SW diagonal:
+//   triangle 1: NW, NE, SW    triangle 2: NE, SE, SW
+// Because all four corners are mapped exactly (no parallelogram extrapolation
+// of SE), adjacent tiles share identical corner positions and identical edge
+// chords, so the tile mosaic is gap-free at every zoom level by construction.
+function drawImageQuad(img, sx, sy, sw, sh, pNW, pNE, pSW, pSE) {
+	drawImageTriangle(img, sx, sy, sx + sw, sy, sx, sy + sh, pNW, pNE, pSW);
+	drawImageTriangle(img, sx + sw, sy, sx + sw, sy + sh, sx, sy + sh, pNE, pSE, pSW);
+}
+
+function drawTile(i, j, tempZoomLevel, maxtile) {
+	const tx = fix_data.tilePos.x + i;
+	const ty = fix_data.tilePos.y + j;
+
+	// web mercator never wraps vertically — skip out-of-range rows instead
+	if (ty < 0 || ty > maxtile)
+		return;
+
+	// proper positive modulo for horizontal antimeridian wrap (any negative tx)
+	const wrappedX = ((tx % (maxtile + 1)) + (maxtile + 1)) % (maxtile + 1);
+
+	// All four ENU corners of this tile. tileToCoord is evaluated with the
+	// *unwrapped* tx so tiles across the antimeridian still land at a
+	// continuous easting (sin/cos of longitude are periodic).
+	const nw = tileCornerEnu(tx,     ty,     tempZoomLevel);
+	const ne = tileCornerEnu(tx + 1, ty,     tempZoomLevel);
+	const sw = tileCornerEnu(tx,     ty + 1, tempZoomLevel);
+	const se = tileCornerEnu(tx + 1, ty + 1, tempZoomLevel);
+
+	const tileURL = server_url.replace("{z}", tempZoomLevel).replace("{x}", wrappedX).replace("{y}", ty);
 	let tileImage = navsat.live_cache[tileURL];
 	let parentCrop = null;
 
 	if (!tileImage || !tileImage.complete) {
 		navsat.enqueue(tileURL);
-		parentCrop = findParentTile(x, y, tempZoomLevel);
+		parentCrop = findParentTile(wrappedX, ty, tempZoomLevel);
 		if (!parentCrop)
 			tileImage = placeholder;
 	}
-	let transformed;
-	if (!ignoreRotationCheckbox.checked) {
-		transformed = tf.transformPoseStamped(map_fix.header, {x: -offsetX, y: offsetY, z: 0}, new Quaternion());
-	} else {
-		transformed = tf.transformPoseStamped(map_fix.header, {x: 0, y: 0, z: 0}, new Quaternion());
-		transformed.translation.x -= offsetX;
-		transformed.translation.y += offsetY;
-		transformed.rotation = new Quaternion();
+
+	// Transform the four corners through the TF tree so the tile inherits the
+	// robot/map rotation exactly like every other rendered element. Using
+	// transformPoseStamped for all four keeps the TF sample identical.
+	function transformCorner(enu) {
+		if (!ignoreRotationCheckbox.checked) {
+			return tf.transformPoseStamped(map_fix.header, {x: enu.x, y: enu.y, z: 0}, new Quaternion());
+		} else {
+			const t = tf.transformPoseStamped(map_fix.header, {x: 0, y: 0, z: 0}, new Quaternion());
+			t.translation.x += enu.x;
+			t.translation.y += enu.y;
+			t.rotation = new Quaternion();
+			return t;
+		}
 	}
 
-	const pos = view.fixedToScreen({x: transformed.translation.x, y: transformed.translation.y});
-	const matrix = view.quaterionToProjectionMatrix(transformed.rotation);
-	ctx.setTransform(matrix[0], matrix[1], matrix[2], matrix[3], pos.x, pos.y);
+	function inflateCorners(pNW, pNE, pSW, pSE, grow){
+		const cx = (pNW.x+pNE.x+pSW.x+pSE.x)/4;
+		const cy = (pNW.y+pNE.y+pSW.y+pSE.y)/4;
+		const push = (p) => {
+			const dx=p.x-cx, dy=p.y-cy, len=Math.hypot(dx,dy)||1;
+			return { x:p.x+(dx/len)*grow, y:p.y+(dy/len)*grow };
+		};
+		return [push(pNW), push(pNE), push(pSW), push(pSE)];
+	}
 
+	const tNW = transformCorner(nw);
+	const tNE = transformCorner(ne);
+	const tSW = transformCorner(sw);
+	const tSE = transformCorner(se);
+
+	const pNW = view.fixedToScreen({x: tNW.translation.x, y: tNW.translation.y});
+	const pNE = view.fixedToScreen({x: tNE.translation.x, y: tNE.translation.y});
+	const pSW = view.fixedToScreen({x: tSW.translation.x, y: tSW.translation.y});
+	const pSE = view.fixedToScreen({x: tSE.translation.x, y: tSE.translation.y});
+
+	const [iNW, iNE, iSW, iSE] = inflateCorners(pNW, pNE, pSW, pSE, 1.4);
+
+	// Map the image onto the exact quadrilateral. The SE corner is no longer
+	// extrapolated as a parallelogram (NE + SW - NW) — the tile footprint in a
+	// tangent plane is a trapezoid, and that extrapolation is what produced
+	// the triangular gaps between the bottom corners of adjacent tiles when
+	// zoomed far out.
 	if (parentCrop){
-		ctx.globalAlpha = opacitySlider.value * 0.8;
-		ctx.drawImage(parentCrop.image, parentCrop.srcX, parentCrop.srcY, parentCrop.srcSize, parentCrop.srcSize, 0, 0, screenSize, screenSize);
-		ctx.globalAlpha = opacitySlider.value;
+		//ctx.globalAlpha = opacitySlider.value * 0.8;
+		drawImageQuad(parentCrop.image, parentCrop.srcX, parentCrop.srcY, parentCrop.srcSize, parentCrop.srcSize, iNW, iNE, iSW, iSE);
+		//ctx.globalAlpha = opacitySlider.value;
 	}
-	else
-		ctx.drawImage(tileImage, 0, 0, screenSize, screenSize);
+	else {
+		const sw_px = tileImage.naturalWidth || navsat.tile_size;
+		const sh_px = tileImage.naturalHeight || navsat.tile_size;
+		drawImageQuad(tileImage, 0, 0, sw_px, sh_px, iNW, iNE, iSW, iSE);
+	}
 }
 
 function clamp(val, from, to){
@@ -203,7 +333,7 @@ async function drawTiles(){
     const hei = canvas.height;
 
 	ctx.clearRect(0, 0, wid, hei);
-	ctx.globalAlpha = opacitySlider.value;
+	ctx.globalAlpha = 1.0;//opacitySlider.value;
 	ctx.imageSmoothingEnabled = smoothingCheckbox.checked;
 
 	if(!map_fix){
@@ -228,8 +358,8 @@ async function drawTiles(){
 
 	if(frame){
 
-		let metersSize = navsat.tileSizeInMeters(map_fix.latitude, tempZoomLevel)
-		const tileScreenSize = view.getMapUnitsInPixels(metersSize);
+		cornerCache.clear();
+
 		const corners = [
 			{ x: 0, y: 0, z: 0 },
 			{ x: wid, y: 0, z: 0 },
@@ -237,35 +367,35 @@ async function drawTiles(){
 			{ x: 0, y: hei, z: 0  },
 		];
 
-		// Convert the corners from pixels to meters, transform them to map_fix frame and convert to latitude, longitude
+		// Convert the corners from pixels to ENU meters in the map_fix frame,
+		// then invert the exact same ENU projection used for tile placement to
+		// get latitude/longitude. Because culling and drawing now use one and
+		// the same (exact, invertible) mapping, they can never diverge no
+		// matter how far the view moves from the origin.
+		// Note: the inverse transform uses the same stamped absolute transform
+		// ("frame") that transformPoseStamped uses in drawTile, so cull and
+		// draw also agree on the TF sample.
 		const cornerCoords = corners.map((corner) => {
 			const meters = view.screenToFixed(corner);
-
-			let transformed;
-			if(ignoreRotationCheckbox.checked){
-				transformed = {
-					translation: {
-						x: -frame.translation.x + meters.x,
-						y: -frame.translation.y + meters.y
-					}
-				}
-			}else{
-				transformed = tf.transformPose(
-					tf.fixed_frame,
-					map_fix.header.frame_id,
-					meters,
-					new Quaternion()
-				);
-			}
-			return {
-				latitude: map_fix.latitude + (transformed.translation.y * fix_data.degreesPerMeter.latitude),
-				longitude: map_fix.longitude + (transformed.translation.x * fix_data.degreesPerMeter.longitude)
+			const d = {
+				x: meters.x - frame.translation.x,
+				y: meters.y - frame.translation.y,
+				z: -frame.translation.z
 			};
+
+			let local;
+			if(ignoreRotationCheckbox.checked){
+				local = d;
+			}else{
+				local = applyRotation(d, frame.rotation, true);
+			}
+
+			return Navsat.enuGroundToLla(local.x, local.y, enu_origin);
 		});
 
-		// Convert the corners to tile coordinates
+		// Convert the corners to tile coordinates (exact mercator)
 		const cornerTileCoords = cornerCoords.map((coord) =>
-			navsat.coordToTile(coord.longitude, coord.latitude, tempZoomLevel)
+			Navsat.coordToTile(coord.longitude, coord.latitude, tempZoomLevel)
 		);
 
 		// Calculate the range of tiles to cover the screen
@@ -289,7 +419,7 @@ async function drawTiles(){
 		const maxDimension = Math.max(matrixWidth, matrixHeight);
 		for (let i = 0; i < maxDimension ** 2; i++) {
 			if (-matrixWidth / 2 < x && x <= matrixWidth / 2 && -matrixHeight / 2 < y && y <= matrixHeight / 2) {
-				drawTile(tileScreenSize, centerX+x, centerY+y, metersSize, tempZoomLevel, maxtile);
+				drawTile(centerX+x, centerY+y, tempZoomLevel, maxtile);
 			}
 			if (x === y || (x < 0 && x === -y) || (x > 0 && x === 1 - y)) {
 				[dx, dy] = [-dy, dx];
@@ -301,14 +431,16 @@ async function drawTiles(){
 		//transform reset
 		ctx.setTransform(1, 0, 0, 1, 0, 0);
 
-		ctx.globalAlpha = 0.6;
-		ctx.fillStyle = "#171717";
-		ctx.fillRect(0, hei-20, 120, 20);
+		if(copyright != ""){
+			ctx.globalAlpha = 0.6;
+			ctx.fillStyle = "#171717";
+			ctx.fillRect(0, hei-20, 120, 20);
 
-		ctx.globalAlpha = 1.0;
-		ctx.font = "12px Monospace";
-		ctx.fillStyle = "white";
-		ctx.fillText(copyright, 5, hei-5);
+			ctx.globalAlpha = 1.0;
+			ctx.font = "12px Monospace";
+			ctx.fillStyle = "white";
+			ctx.fillText(copyright, 5, hei-5);
+		}
 
 		status.setOK();
 	}else{
@@ -377,24 +509,15 @@ function connect(){
 }
 
 function updateFixData(){
-	const tilePos = navsat.coordToTile(map_fix.longitude, map_fix.latitude, zoomLevel);
-	const tileCoords = navsat.tileToCoord(tilePos.x, tilePos.y, zoomLevel);
-	const nextTileCoords = navsat.tileToCoord(tilePos.x+1, tilePos.y+1, zoomLevel);
-	const metersSize = navsat.tileSizeInMeters(map_fix.latitude, zoomLevel);
+	// The ENU tangent plane is anchored at the fix coordinate. If the backend
+	// projects GNSS with a fixed datum (recommended), make sure this topic
+	// publishes that datum so both ENU frames coincide exactly.
+	const alt = Number.isFinite(map_fix.altitude) ? map_fix.altitude : 0;
+	enu_origin = Navsat.buildEnuOrigin(map_fix.latitude, map_fix.longitude, alt);
 
 	fix_data = {
-		tilePos: tilePos,
-		tileCoords: tileCoords,
-		offset:{
-			x: navsat.haversine(map_fix.latitude, tileCoords.longitude, map_fix.latitude, map_fix.longitude),
-			y: navsat.haversine(tileCoords.latitude, map_fix.longitude, map_fix.latitude, map_fix.longitude)
-		},
-		metersSize: metersSize,
-		degreesPerMeter: {
-			longitude: Math.abs(tileCoords.longitude - nextTileCoords.longitude)/metersSize,
-			latitude: Math.abs(tileCoords.latitude - nextTileCoords.latitude)/metersSize
-		}
-	}
+		tilePos: Navsat.coordToTile(map_fix.longitude, map_fix.latitude, zoomLevel)
+	};
 }
 
 async function loadTopics(){

--- a/public/templates/satelite/satelite_script.js
+++ b/public/templates/satelite/satelite_script.js
@@ -529,7 +529,6 @@ function connect(){
 		if(fix_key !== last_fix_key){
 			last_fix_key = fix_key;
 			updateFixData();
-			console.log("dropping corner cache");
 		}
 		
 		drawTiles();

--- a/public/templates/satelite/satelite_script.js
+++ b/public/templates/satelite/satelite_script.js
@@ -29,6 +29,7 @@ let map_topic = undefined;
 let map_fix = undefined;
 let fix_data = undefined;
 let enu_origin = undefined;
+let enuToScreenMat = undefined;
 
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const icon = document.getElementById("{uniqueID}_icon").getElementsByTagName('img')[0];
@@ -170,6 +171,11 @@ function tileCornerEnu(x, y, z){
 	if(v === undefined){
 		const c = Navsat.tileToCoord(x, y, z);
 		v = Navsat.llaToEnu(c.latitude, c.longitude, undefined, enu_origin); // at origin altitude
+
+		//clear if it gets over 1MB
+		if (cornerCache.size > 16384)
+			cornerCache.clear();
+
 		cornerCache.set(key, v);
 	}
 	return v;
@@ -265,21 +271,6 @@ function drawTile(i, j, tempZoomLevel, maxtile) {
 			tileImage = placeholder;
 	}
 
-	// Transform the four corners through the TF tree so the tile inherits the
-	// robot/map rotation exactly like every other rendered element. Using
-	// transformPoseStamped for all four keeps the TF sample identical.
-	function transformCorner(enu) {
-		if (!ignoreRotationCheckbox.checked) {
-			return tf.transformPoseStamped(map_fix.header, {x: enu.x, y: enu.y, z: 0}, new Quaternion());
-		} else {
-			const t = tf.transformPoseStamped(map_fix.header, {x: 0, y: 0, z: 0}, new Quaternion());
-			t.translation.x += enu.x;
-			t.translation.y += enu.y;
-			t.rotation = new Quaternion();
-			return t;
-		}
-	}
-
 	function inflateCorners(pNW, pNE, pSW, pSE, grow){
 		const cx = (pNW.x+pNE.x+pSW.x+pSE.x)/4;
 		const cy = (pNW.y+pNE.y+pSW.y+pSE.y)/4;
@@ -290,15 +281,18 @@ function drawTile(i, j, tempZoomLevel, maxtile) {
 		return [push(pNW), push(pNE), push(pSW), push(pSE)];
 	}
 
-	const tNW = transformCorner(nw);
-	const tNE = transformCorner(ne);
-	const tSW = transformCorner(sw);
-	const tSE = transformCorner(se);
+	function enuToScreen(p){
+		const m = enuToScreenMat;
+		return {
+			x: m.a * p.x + m.b * p.y + m.e,
+			y: m.c * p.x + m.d * p.y + m.f
+		};
+	}
 
-	const pNW = view.fixedToScreen({x: tNW.translation.x, y: tNW.translation.y});
-	const pNE = view.fixedToScreen({x: tNE.translation.x, y: tNE.translation.y});
-	const pSW = view.fixedToScreen({x: tSW.translation.x, y: tSW.translation.y});
-	const pSE = view.fixedToScreen({x: tSE.translation.x, y: tSE.translation.y});
+	const pNW = enuToScreen(nw);
+	const pNE = enuToScreen(ne);
+	const pSW = enuToScreen(sw);
+	const pSE = enuToScreen(se);
 
 	const [iNW, iNE, iSW, iSE] = inflateCorners(pNW, pNE, pSW, pSE, 1.4);
 
@@ -308,9 +302,7 @@ function drawTile(i, j, tempZoomLevel, maxtile) {
 	// the triangular gaps between the bottom corners of adjacent tiles when
 	// zoomed far out.
 	if (parentCrop){
-		//ctx.globalAlpha = opacitySlider.value * 0.8;
 		drawImageQuad(parentCrop.image, parentCrop.srcX, parentCrop.srcY, parentCrop.srcSize, parentCrop.srcSize, iNW, iNE, iSW, iSE);
-		//ctx.globalAlpha = opacitySlider.value;
 	}
 	else {
 		const sw_px = tileImage.naturalWidth || navsat.tile_size;
@@ -334,7 +326,7 @@ async function drawTiles(){
     const hei = canvas.height;
 
 	ctx.clearRect(0, 0, wid, hei);
-	ctx.globalAlpha = 1.0;//opacitySlider.value;
+	ctx.globalAlpha = 1.0;
 	ctx.imageSmoothingEnabled = smoothingCheckbox.checked;
 
 	if(!map_fix){
@@ -359,7 +351,20 @@ async function drawTiles(){
 
 	if(frame){
 
-		cornerCache.clear();
+		// ENU -> screen is one affine per frame: screen = S * (R * enu + t).
+		// Build it once; per corner it's then 4 multiplies + 2 adds.
+		const ignoreRot = ignoreRotationCheckbox.checked;
+		const q = frame.rotation;
+		const m00 = ignoreRot ? 1 : 1 - 2 * (q.y * q.y + q.z * q.z);
+		const m01 = ignoreRot ? 0 : 2 * (q.x * q.y - q.w * q.z);
+		const m10 = ignoreRot ? 0 : 2 * (q.x * q.y + q.w * q.z);
+		const m11 = ignoreRot ? 1 : 1 - 2 * (q.x * q.x + q.z * q.z);
+		const p0 = view.fixedToScreen({x: frame.translation.x, y: frame.translation.y});
+		const s = view.scale;
+		enuToScreenMat = {
+			a:  s * m00, b:  s * m01, e: p0.x,
+			c: -s * m10, d: -s * m11, f: p0.y
+		};
 
 		const corners = [
 			{ x: 0, y: 0, z: 0 },
@@ -513,6 +518,8 @@ function connect(){
 }
 
 function updateFixData(){
+	cornerCache.clear();
+
 	// The ENU tangent plane is anchored at the fix coordinate. If the backend
 	// projects GNSS with a fixed datum (recommended), make sure this topic
 	// publishes that datum so both ENU frames coincide exactly.

--- a/public/templates/satelite/satelite_script.js
+++ b/public/templates/satelite/satelite_script.js
@@ -457,6 +457,8 @@ const COVARIANCE_TYPE = {
 	3: "(known)"
 }
 
+let connect_retry = 0;
+
 //Topic
 function connect(){
 
@@ -516,8 +518,16 @@ function connect(){
 
 		if(!frame){
 			status.setError("Required transform frame \""+msg.header.frame_id+"\" not found.");
+			connect_retry = (connect_retry + 1) % 5;
+			if(connect_retry != 0){
+				console.log("Satelite tiles connect retry...")
+				setTimeout(connect, 500);
+				return;
+			}
 			return;
 		}
+
+		connect_retry = 0;
 		msg.frame = frame;
 		
 		map_fix = msg;

--- a/public/templates/satelite/satelite_script.js
+++ b/public/templates/satelite/satelite_script.js
@@ -30,6 +30,8 @@ let map_fix = undefined;
 let fix_data = undefined;
 let enu_origin = undefined;
 let enuToScreenMat = undefined;
+let last_fix_key = undefined;
+let update_throttle = undefined;
 
 const selectionbox = document.getElementById("{uniqueID}_topic");
 const icon = document.getElementById("{uniqueID}_icon").getElementsByTagName('img')[0];
@@ -338,8 +340,6 @@ async function drawTiles(){
 		return;
 	}
 
-	const frame = tf.getAbsoluteTransform(map_fix.header);
-
 	let	tempZoomLevel = Math.round(Math.log2(view.scale)+17);
 	tempZoomLevel = clamp(tempZoomLevel, 7, 19);
 	if(tempZoomLevel != zoomLevel){
@@ -349,109 +349,105 @@ async function drawTiles(){
 	}
 
 
-	if(frame){
+	// ENU -> screen is one affine per frame: screen = S * (R * enu + t).
+	// Build it once; per corner it's then 4 multiplies + 2 adds.
+	const frame = map_fix.frame;
+	const ignoreRot = ignoreRotationCheckbox.checked;
+	const q = frame.rotation;
+	const m00 = ignoreRot ? 1 : 1 - 2 * (q.y * q.y + q.z * q.z);
+	const m01 = ignoreRot ? 0 : 2 * (q.x * q.y - q.w * q.z);
+	const m10 = ignoreRot ? 0 : 2 * (q.x * q.y + q.w * q.z);
+	const m11 = ignoreRot ? 1 : 1 - 2 * (q.x * q.x + q.z * q.z);
+	const p0 = view.fixedToScreen({x: frame.translation.x, y: frame.translation.y});
+	const s = view.scale;
+	enuToScreenMat = {
+		a:  s * m00, b:  s * m01, e: p0.x,
+		c: -s * m10, d: -s * m11, f: p0.y
+	};
 
-		// ENU -> screen is one affine per frame: screen = S * (R * enu + t).
-		// Build it once; per corner it's then 4 multiplies + 2 adds.
-		const ignoreRot = ignoreRotationCheckbox.checked;
-		const q = frame.rotation;
-		const m00 = ignoreRot ? 1 : 1 - 2 * (q.y * q.y + q.z * q.z);
-		const m01 = ignoreRot ? 0 : 2 * (q.x * q.y - q.w * q.z);
-		const m10 = ignoreRot ? 0 : 2 * (q.x * q.y + q.w * q.z);
-		const m11 = ignoreRot ? 1 : 1 - 2 * (q.x * q.x + q.z * q.z);
-		const p0 = view.fixedToScreen({x: frame.translation.x, y: frame.translation.y});
-		const s = view.scale;
-		enuToScreenMat = {
-			a:  s * m00, b:  s * m01, e: p0.x,
-			c: -s * m10, d: -s * m11, f: p0.y
+	const corners = [
+		{ x: 0, y: 0, z: 0 },
+		{ x: wid, y: 0, z: 0 },
+		{ x: wid, y: hei, z: 0  },
+		{ x: 0, y: hei, z: 0  },
+	];
+
+	// Convert the corners from pixels to ENU meters in the map_fix frame,
+	// then invert the exact same ENU projection used for tile placement to
+	// get latitude/longitude. Because culling and drawing now use one and
+	// the same (exact, invertible) mapping, they can never diverge no
+	// matter how far the view moves from the origin.
+	// Note: the inverse transform uses the same stamped absolute transform
+	// ("frame") that transformPoseStamped uses in drawTile, so cull and
+	// draw also agree on the TF sample.
+	const cornerCoords = corners.map((corner) => {
+		const meters = view.screenToFixed(corner);
+		const d = {
+			x: meters.x - frame.translation.x,
+			y: meters.y - frame.translation.y,
+			z: -frame.translation.z
 		};
 
-		const corners = [
-			{ x: 0, y: 0, z: 0 },
-			{ x: wid, y: 0, z: 0 },
-			{ x: wid, y: hei, z: 0  },
-			{ x: 0, y: hei, z: 0  },
-		];
-
-		// Convert the corners from pixels to ENU meters in the map_fix frame,
-		// then invert the exact same ENU projection used for tile placement to
-		// get latitude/longitude. Because culling and drawing now use one and
-		// the same (exact, invertible) mapping, they can never diverge no
-		// matter how far the view moves from the origin.
-		// Note: the inverse transform uses the same stamped absolute transform
-		// ("frame") that transformPoseStamped uses in drawTile, so cull and
-		// draw also agree on the TF sample.
-		const cornerCoords = corners.map((corner) => {
-			const meters = view.screenToFixed(corner);
-			const d = {
-				x: meters.x - frame.translation.x,
-				y: meters.y - frame.translation.y,
-				z: -frame.translation.z
-			};
-
-			let local;
-			if(ignoreRotationCheckbox.checked){
-				local = d;
-			}else{
-				local = applyRotation(d, frame.rotation, true);
-			}
-
-			return Navsat.enuGroundToLla(local.x, local.y, enu_origin);
-		});
-
-		// Convert the corners to tile coordinates (exact mercator)
-		const cornerTileCoords = cornerCoords.map((coord) =>
-			Navsat.coordToTile(coord.longitude, coord.latitude, tempZoomLevel)
-		);
-
-		// Calculate the range of tiles to cover the screen
-		const minX = Math.min(...cornerTileCoords.map((coord) => coord.x)) - fix_data.tilePos.x - 1;
-		const maxX = Math.max(...cornerTileCoords.map((coord) => coord.x)) - fix_data.tilePos.x + 1;
-		const minY = Math.min(...cornerTileCoords.map((coord) => coord.y)) - fix_data.tilePos.y - 1;
-		const maxY = Math.max(...cornerTileCoords.map((coord) => coord.y)) - fix_data.tilePos.y + 1;
-
-		//draw tiles in concentric circles, starting from the center of the screen
-		const matrixWidth = (maxX - minX)+2;
-		const matrixHeight = (maxY - minY)+2;
-		const centerX = Math.round((maxX+minX)/2);
-		const centerY = Math.round((maxY+minY)/2)-1;
-		const maxtile = Math.pow(2, tempZoomLevel) - 1;
-
-		let x = 0;
-		let y = 0;
-		let dx = 0;
-		let dy = -1;
-
-		const maxDimension = Math.max(matrixWidth, matrixHeight);
-		for (let i = 0; i < maxDimension ** 2; i++) {
-			if (-matrixWidth / 2 < x && x <= matrixWidth / 2 && -matrixHeight / 2 < y && y <= matrixHeight / 2) {
-				drawTile(centerX+x, centerY+y, tempZoomLevel, maxtile);
-			}
-			if (x === y || (x < 0 && x === -y) || (x > 0 && x === 1 - y)) {
-				[dx, dy] = [-dy, dx];
-			}
-			x += dx;
-			y += dy;
+		let local;
+		if(ignoreRotationCheckbox.checked){
+			local = d;
+		}else{
+			local = applyRotation(d, frame.rotation, true);
 		}
 
-		//transform reset
-		ctx.setTransform(1, 0, 0, 1, 0, 0);
+		return Navsat.enuGroundToLla(local.x, local.y, enu_origin);
+	});
 
-		if(copyright != ""){
-			ctx.globalAlpha = 0.6;
-			ctx.fillStyle = "#171717";
-			ctx.fillRect(0, hei-20, 120, 20);
+	// Convert the corners to tile coordinates (exact mercator)
+	const cornerTileCoords = cornerCoords.map((coord) =>
+		Navsat.coordToTile(coord.longitude, coord.latitude, tempZoomLevel)
+	);
 
-			ctx.globalAlpha = 1.0;
-			ctx.font = "12px Monospace";
-			ctx.fillStyle = "white";
-			ctx.fillText(copyright, 5, hei-5);
+	// Calculate the range of tiles to cover the screen
+	const minX = Math.min(...cornerTileCoords.map((coord) => coord.x)) - fix_data.tilePos.x - 1;
+	const maxX = Math.max(...cornerTileCoords.map((coord) => coord.x)) - fix_data.tilePos.x + 1;
+	const minY = Math.min(...cornerTileCoords.map((coord) => coord.y)) - fix_data.tilePos.y - 1;
+	const maxY = Math.max(...cornerTileCoords.map((coord) => coord.y)) - fix_data.tilePos.y + 1;
+
+	//draw tiles in concentric circles, starting from the center of the screen
+	const matrixWidth = (maxX - minX)+2;
+	const matrixHeight = (maxY - minY)+2;
+	const centerX = Math.round((maxX+minX)/2);
+	const centerY = Math.round((maxY+minY)/2)-1;
+	const maxtile = Math.pow(2, tempZoomLevel) - 1;
+
+	let x = 0;
+	let y = 0;
+	let dx = 0;
+	let dy = -1;
+
+	const maxDimension = Math.max(matrixWidth, matrixHeight);
+	for (let i = 0; i < maxDimension ** 2; i++) {
+		if (-matrixWidth / 2 < x && x <= matrixWidth / 2 && -matrixHeight / 2 < y && y <= matrixHeight / 2) {
+			drawTile(centerX+x, centerY+y, tempZoomLevel, maxtile);
 		}
-
-		status.setOK();
-	}else{
-		status.setError("Required transform frame \""+map_fix.header.frame_id+"\" not found.");
+		if (x === y || (x < 0 && x === -y) || (x > 0 && x === 1 - y)) {
+			[dx, dy] = [-dy, dx];
+		}
+		x += dx;
+		y += dy;
 	}
+
+	//transform reset
+	ctx.setTransform(1, 0, 0, 1, 0, 0);
+
+	if(copyright != ""){
+		ctx.globalAlpha = 0.6;
+		ctx.fillStyle = "#171717";
+		ctx.fillRect(0, hei-20, 120, 20);
+
+		ctx.globalAlpha = 1.0;
+		ctx.font = "12px Monospace";
+		ctx.fillStyle = "white";
+		ctx.fillText(copyright, 5, hei-5);
+	}
+
+	status.setOK();
 }
 
 const COVARIANCE_TYPE = {
@@ -476,8 +472,7 @@ function connect(){
 	map_topic = new ROSLIB.Topic({
 		ros : rosbridge.ros,
 		name : topic,
-		messageType : 'sensor_msgs/NavSatFix',
-		throttle_rate: 33
+		messageType : 'sensor_msgs/NavSatFix'
 	});
 
 	status.setWarn("No data received.");
@@ -486,8 +481,16 @@ function connect(){
 	text_alt.innerText = "Altitude: ?";
 	text_cov.innerText = "Ground Covariance: ?";
 	text_frame.innerText = "TF Frame: ?";
+
+	last_fix_key = undefined;
+	update_throttle = new Date("2010-3-2");
 	
 	listener = map_topic.subscribe((msg) => {
+		if(new Date() - update_throttle < 4000 || opacitySlider.value == 0.0) //reduces jitter and CPU load in raw receiver mode
+			return;
+
+		update_throttle = new Date();
+
 		const cov_mat = msg.position_covariance;
 		const covariance_meters = Math.hypot(Math.sqrt(cov_mat[0]), Math.sqrt(cov_mat[4]))
 
@@ -509,8 +512,26 @@ function connect(){
 
 		text_frame.innerText = "TF Frame: "+msg.header.frame_id;
 
+		const frame = tf.getAbsoluteTransform(msg.header);
+
+		if(!frame){
+			status.setError("Required transform frame \""+msg.header.frame_id+"\" not found.");
+			return;
+		}
+		msg.frame = frame;
+		
 		map_fix = msg;
-		updateFixData();
+
+		// Only rebuild the ENU origin and tile state if the actual fix changed.
+		// If it's the same position with a new header, no need to dump the corner cache and redo all the tile math.
+		const cov = msg.position_covariance;
+		const fix_key = `${msg.latitude},${msg.longitude},${msg.altitude},${cov[0]},${cov[4]},${cov[8]}`;
+		if(fix_key !== last_fix_key){
+			last_fix_key = fix_key;
+			updateFixData();
+			console.log("dropping corner cache");
+		}
+		
 		drawTiles();
 	});
 

--- a/public/templates/teleop/teleop_script.js
+++ b/public/templates/teleop/teleop_script.js
@@ -881,6 +881,9 @@ function updateKeyButtons() {
 
 function keydown(event) {
 
+	if(event.key === undefined)
+		return;
+
 	if(joy_locked)
 		return;
 
@@ -926,6 +929,9 @@ function keydown(event) {
 }
 
 function keyup(event) {
+
+	if(event.key === undefined)
+		return;
 
 	if(joy_locked)
 		return;


### PR DESCRIPTION
The original implementation of how to tiles are rendered relative to the origin makes a few too many simplistic assumptions, keeps tiles the same size as the origin and stacks them. That leads to drift between the displayed locations and the actual lat/lon data projected into the TF tree using ENU. It's usable within a few km, but at 100km out, the error approaches 500m.

The correct projection is a literal globe centred directly under the the origin:

<img width="573" height="547" alt="image" src="https://github.com/user-attachments/assets/55c9a163-178c-4cda-bc24-c897e75da288" />

The new implementation both follows the geodesic process of turning LLA into ENU and optimizes the rendering pipeline for more accurate culling and better caching.

Verified with a 150km trajectory, there is now zero cumulative drift between tiles and the transformed GNSS receiver locations in TF relative to the same origin, since both projections match exactly.

Z values become less useful further out since they drift slowly into orbit, but XY stay consistent as an orthographic downwards projection of every point, at least as long as you don't fall off the edge of the planet. The heading is only correct at the origin itself too, and sensors that report it in true or magnetic north will agree less and less (~1 deg per 100km) as the distance increases.

This should theoretically make it possible to set up extremely long waypoint missions that can be correctly transformed into ECEF or LLA on the backend without issues. 

https://github.com/user-attachments/assets/35f2c983-d891-4b22-91ae-791d4c9cd99f

